### PR TITLE
[Skills] Improve error logging and remote client discoverability

### DIFF
--- a/skills/skills_provider.py
+++ b/skills/skills_provider.py
@@ -165,8 +165,8 @@ def setup_skills_provider(
 
             logger.info(f"Generated skills for {module_name} -> {skill_dir}")
 
-        except Exception as e:
-            logger.error(f"Failed to generate skills for {module_name}: {e}")
+        except Exception:
+            logger.exception(f"Failed to generate skills for {module_name}")
             continue
 
     # Generate cross-module server skill (combines card + email symbol maps)
@@ -184,8 +184,8 @@ def setup_skills_provider(
         if card_w and email_w:
             write_server_skill(skills_root, card_w, email_w)
             skills_generated = True
-    except Exception as e:
-        logger.error(f"Failed to generate server skill: {e}")
+    except Exception:
+        logger.exception("Failed to generate server skill")
 
     if not skills_generated:
         logger.warning("No skills were generated")
@@ -196,11 +196,12 @@ def setup_skills_provider(
         provider = SkillsDirectoryProvider(
             roots=skills_root,
             reload=auto_regenerate,  # Re-scan on each request if regenerating
+            supporting_files="resources",  # Expose every file in list_resources for remote clients that don't follow the manifest->template flow
         )
         mcp.add_provider(provider)
         logger.info(f"Skills provider registered: {skills_root}")
-    except Exception as e:
-        logger.error(f"Failed to register skills provider: {e}")
+    except Exception:
+        logger.exception("Failed to register skills provider")
         return None
 
     return skills_root


### PR DESCRIPTION
## Summary

- Switch three swallowed `logger.error(f"...: {e}")` calls in `setup_skills_provider` to `logger.exception(...)` — same non-fatal behavior, but full tracebacks in logs so silent failures are diagnosable in production.
- Set `supporting_files="resources"` on `SkillsDirectoryProvider` so every skill file (components, symbols, DSL docs, jinja filters) appears in `resources/list` — remote clients no longer need the manifest→template two-step flow to discover them.

## Context

Reported that a remote client (Roo) couldn't reach the `MJML Email Composer` skill from the prod MCP server. Investigation showed the server-side `SkillsDirectoryProvider` pattern is correct — skills are exposed as MCP Resources with `skill://` URIs, and the server reads file content and ships it over the wire. The two issues addressed here are:

1. When skill generation silently fails (e.g., permission errors in a containerized `~/.claude/skills`), the truncated `logger.error` output hid which wrapper broke and why. Tracebacks are restored.
2. With the default `supporting_files="template"`, clients only see `SKILL.md` + `_manifest` in `resources/list`. Every component doc was hidden behind a `ResourceTemplate` that required the client to read the manifest first. Switching to `"resources"` surfaces all files directly.

## Verification

Local HTTP server (`MCP_TRANSPORT=http port=8002`) probed via `resources/list`:
- Before: main files + manifests only (~8 entries)
- After: **1,118 `skill://` URIs** across `gchat-cards`, `mjml-email`, `qdrant-search`, `google-workspace-mcp`

Sample reads confirmed content delivery works:
- `skill://mjml-email/SKILL.md` → markdown content
- `skill://mjml-email/components/ButtonBlock.md` → markdown content (this path would not be in `resources/list` under the old default)

Already merged in a private downstream repo (`google_workspace_fastmcp2_temp` PR #1) before promotion here.

## Test plan

- [x] `ruff check` on modified file — clean
- [x] `ruff format` on modified file — no changes
- [x] Server starts cleanly in HTTP mode with `ENABLE_SKILLS_PROVIDER=true`
- [x] `resources/list` enumerates all skill files (1,118 URIs)
- [x] `resources/read` on both main and supporting-file URIs returns content
- [ ] Deploy to prod and confirm remote clients can enumerate the full skill tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)