### PR TITLE
Fix CI test drift: RIC protocol, cost fields, placeholder marker

### DIFF
--- a/middleware/qdrant_core/tool_response_provider.py
+++ b/middleware/qdrant_core/tool_response_provider.py
@@ -96,6 +96,12 @@ class ToolResponseProvider:
             parts.append(f"Session: {session_id}.")
         return " ".join(parts)
 
+    def content_text(self, name: str, metadata: Dict[str, Any]) -> str:
+        """Tool-response user content. Returns empty string (response payload is
+        already embedded via inputs_text). Present to satisfy the RICTextProvider
+        Protocol; matches IntrospectionProvider's class-point behavior."""
+        return ""
+
 
 __all__ = [
     "ToolResponseProvider",

--- a/tests/test_cost_tracker.py
+++ b/tests/test_cost_tracker.py
@@ -108,6 +108,7 @@ class TestCostTracker:
             "sampling_calls",
             "sampling_estimated_input_tokens",
             "sampling_estimated_output_tokens",
+            "sampling_estimated_cached_tokens",
             "cost_sampling_estimated",
             "sampling_model",
         }

--- a/tests/test_input_resolver_mixin.py
+++ b/tests/test_input_resolver_mixin.py
@@ -323,26 +323,28 @@ class TestConsumeFromContext:
         assert context["_button_index"] == 3
 
     def test_overflow_button(self):
-        """When resources exhausted, overflow handler provides fallback."""
+        """When resources exhausted, overflow handler provides a fallback dict
+        tagged with _placeholder=True (consumed by component_builder to skip
+        synthesized entries)."""
         context = {"buttons": [], "_button_index": 0}
         result = self.w.consume_from_context("Button", context)
-        assert result == {"text": "Button 1"}
+        assert result == {"text": "Button 1", "_placeholder": True}
         assert context["_button_index"] == 1
 
     def test_overflow_chip(self):
         context = {"chips": [], "_chip_index": 0}
         result = self.w.consume_from_context("Chip", context)
-        assert result == {"label": "Chip 1"}
+        assert result == {"label": "Chip 1", "_placeholder": True}
 
     def test_overflow_carousel_card(self):
         context = {"carousel_cards": [], "_carousel_card_index": 0}
         result = self.w.consume_from_context("CarouselCard", context)
-        assert result == {"title": "Card 1"}
+        assert result == {"title": "Card 1", "_placeholder": True}
 
     def test_overflow_grid_item(self):
         context = {"grid_items": [], "_grid_item_index": 0}
         result = self.w.consume_from_context("GridItem", context)
-        assert result == {"title": "Item 1"}
+        assert result == {"title": "Item 1", "_placeholder": True}
 
     def test_overflow_decorated_text_empty(self):
         """DecoratedText has no overflow handler - returns empty dict."""

--- a/tests/test_ric_provider.py
+++ b/tests/test_ric_provider.py
@@ -91,6 +91,9 @@ class TestRICTextProviderProtocol:
             def relationships_text(self, name: str, metadata: Dict[str, Any]) -> str:
                 return "standalone"
 
+            def content_text(self, name: str, metadata: Dict[str, Any]) -> str:
+                return ""
+
         assert isinstance(MyProvider(), RICTextProvider)
 
 


### PR DESCRIPTION
## Summary

Addresses 7 of the 17 test failures on `main` after the v2.1.0 / PR #39 merge. Three unrelated root causes:

- **RIC Protocol drift (C, 2 failures)** — `ToolResponseProvider` was missing `content_text()`, which the `@runtime_checkable` `RICTextProvider` Protocol now requires (present on `IntrospectionProvider`). Added `content_text() → ""` to match `IntrospectionProvider`'s class-point behavior. The test's `MyProvider` stub also updated with the required method.
- **Cost tracker field (E, 1 failure)** — `middleware/payment/cost_tracker.py` emits `sampling_estimated_cached_tokens`; test's `expected_keys` set was stale.
- **Placeholder marker in overflow tests (F, 4 failures)** — `gchat/card_builder/field_extractors.py` intentionally tags synthesized overflow items with `_placeholder: True`; `component_builder.py:370,499` consumes it to filter fallbacks. Tests needed to accept the marker.

### Not addressed in this PR (per out-of-band discussion)
- **A** — 5 payment/receipt failures caused by missing `.auth_encryption_key` in CI (env gap, not a regression).
- **B** — 2 x402 verifier failures in stub mode.
- **D** — 3 `test_code_mode` failures from changed return-value contract (needs a design decision).

## Test plan
- [x] `uv run pytest tests/test_ric_provider.py tests/test_cost_tracker.py tests/test_input_resolver_mixin.py` — 79/79 pass
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [ ] CI runs full suite; the 7 fixed tests should flip to passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)