### PR TITLE
[Drive] Add client-filesystem upload mode for remote MCP clients

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -46,6 +46,17 @@ class Settings(BaseSettings):
     # Attachment download temp directory (for signed URL mode)
     attachment_temp_dir: str = "/tmp/gw-mcp-attachments"
 
+    # Drive upload — client filesystem mode
+    # When True (default), upload_to_drive treats `path` as a path on the
+    # *client's* filesystem and orchestrates client→server→Drive transport
+    # via an HMAC-signed PUT URL (see drive/upload_staging.py and
+    # tools/drive_upload_endpoints.py). When False, `path` is the server's
+    # local filesystem (legacy behavior, suitable for stdio / co-located use).
+    drive_upload_client_fs: bool = True
+    drive_upload_temp_dir: str = "/tmp/gw-mcp-drive-uploads"
+    drive_upload_max_size_mb: int = 100
+    drive_upload_ttl_seconds: int = 900
+
     @property
     def is_cloud_deployment(self) -> bool:
         """Detect if running in FastMCP Cloud."""

--- a/config/settings.py
+++ b/config/settings.py
@@ -47,12 +47,15 @@ class Settings(BaseSettings):
     attachment_temp_dir: str = "/tmp/gw-mcp-attachments"
 
     # Drive upload — client filesystem mode
-    # When True (default), upload_to_drive treats `path` as a path on the
-    # *client's* filesystem and orchestrates client→server→Drive transport
-    # via an HMAC-signed PUT URL (see drive/upload_staging.py and
-    # tools/drive_upload_endpoints.py). When False, `path` is the server's
-    # local filesystem (legacy behavior, suitable for stdio / co-located use).
-    drive_upload_client_fs: bool = True
+    # When False (default), `path` is interpreted as the server's local
+    # filesystem — suitable for stdio and any deployment where the client
+    # and server share a filesystem (the common case).
+    # When True, `upload_to_drive` treats `path` as a path on the *client's*
+    # filesystem and orchestrates client→server→Drive transport via an
+    # HMAC-signed PUT URL (see drive/upload_staging.py and
+    # tools/drive_upload_endpoints.py). Enable this on remote/hosted
+    # deployments where clients and the server are on different machines.
+    drive_upload_client_fs: bool = False
     drive_upload_temp_dir: str = "/tmp/gw-mcp-drive-uploads"
     drive_upload_max_size_mb: int = 100
     drive_upload_ttl_seconds: int = 900

--- a/drive/upload_staging.py
+++ b/drive/upload_staging.py
@@ -1,0 +1,338 @@
+"""Secure staging for client→server→Drive uploads with HMAC-signed PUT URLs.
+
+This is the *inbound* mirror of ``gmail/attachment_server.py``. When
+``settings.drive_upload_client_fs`` is enabled, ``upload_to_drive`` cannot
+read from the server's local filesystem — the path lives on the client.
+Instead the tool issues an HMAC-signed PUT URL; the client uploads file
+content there; ``upload_to_drive`` is re-called and finalizes the Drive
+upload from the staged bytes.
+
+Security:
+    - HMAC-SHA256 signed URLs (HKDF-derived key, distinct ``info`` from
+      attachment downloads)
+    - One-time use via ``ConsumedTokenStore``
+    - UUID-prefixed filenames prevent collisions and guessing
+    - Path traversal protection via ``os.path.realpath()``
+    - Temp dir with ``0o700`` permissions
+    - Eager + lazy file cleanup
+    - Allocations bound to ``(session_id, client_path)`` so phase 2 of the
+      tool call can locate the staged bytes without an extra parameter
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac as _hmac
+import os
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+from urllib.parse import urlencode
+
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+from config.enhanced_logging import setup_logger
+from middleware.token_store import ConsumedTokenStore
+
+logger = setup_logger()
+
+CLEANUP_INTERVAL_SECONDS = 300  # 5 minutes
+_hmac_key_cache: Optional[bytes] = None
+_consumed_uploads = ConsumedTokenStore("drive-upload", default_ttl_seconds=900)
+_cleanup_task: Optional[asyncio.Task] = None
+
+
+@dataclass
+class _Allocation:
+    upload_id: str
+    session_id: str
+    client_path: str
+    filename: str
+    mime_type: str
+    folder_id: str
+    user_email: str
+    custom_filename: Optional[str]
+    allocated_at: float = field(default_factory=time.time)
+    received: bool = False
+
+
+# upload_id -> _Allocation
+_allocations: dict[str, _Allocation] = {}
+# (session_id, client_path) -> upload_id
+_session_index: dict[tuple[str, str], str] = {}
+
+
+def _get_server_secret() -> str:
+    """Read the server secret from ``.auth_encryption_key``."""
+    secret_path = Path(".auth_encryption_key")
+    if secret_path.exists():
+        secret = secret_path.read_text().strip()
+        if secret:
+            return secret
+    import secrets as _secrets
+
+    fallback = _secrets.token_urlsafe(32)
+    logger.warning(
+        "No .auth_encryption_key found; drive upload URLs using random ephemeral key. "
+        "URLs will NOT survive server restarts."
+    )
+    return fallback
+
+
+def _get_hmac_key() -> bytes:
+    """Derive a 32-byte HMAC key via HKDF-SHA256."""
+    global _hmac_key_cache
+    if _hmac_key_cache is not None:
+        return _hmac_key_cache
+
+    secret = _get_server_secret()
+    hkdf = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=b"mcp-google-workspace-v1",
+        info=b"drive-upload-hmac-v1",
+    )
+    _hmac_key_cache = hkdf.derive(secret.encode())
+    return _hmac_key_cache
+
+
+def _compute_signature(params: dict) -> str:
+    """Compute HMAC-SHA256 over canonical query params (excluding ``sig``)."""
+    data = {k: v for k, v in sorted(params.items()) if k != "sig"}
+    canonical = "&".join(f"{k}={v}" for k, v in data.items())
+    return _hmac.new(_get_hmac_key(), canonical.encode(), hashlib.sha256).hexdigest()
+
+
+def _get_temp_dir() -> str:
+    from config.settings import settings
+
+    temp_dir = settings.drive_upload_temp_dir
+    os.makedirs(temp_dir, mode=0o700, exist_ok=True)
+    return temp_dir
+
+
+def allocate_upload(
+    session_id: str,
+    client_path: str,
+    user_email: str,
+    folder_id: str,
+    custom_filename: Optional[str],
+) -> _Allocation:
+    """Reserve an upload slot for a (session_id, client_path) tuple.
+
+    If an allocation already exists for the same tuple and hasn't received
+    bytes yet, it is returned as-is (idempotent re-issue). If it already
+    received bytes, the existing allocation is returned so the tool can
+    finalize. If it expired, a fresh allocation replaces it.
+    """
+    import mimetypes
+
+    _evict_expired()
+
+    key = (session_id, client_path)
+    existing_id = _session_index.get(key)
+    if existing_id and existing_id in _allocations:
+        return _allocations[existing_id]
+
+    upload_id = uuid.uuid4().hex
+    filename = custom_filename or os.path.basename(client_path) or "upload"
+    mime_type, _ = mimetypes.guess_type(filename)
+    alloc = _Allocation(
+        upload_id=upload_id,
+        session_id=session_id,
+        client_path=client_path,
+        filename=filename,
+        mime_type=mime_type or "application/octet-stream",
+        folder_id=folder_id,
+        user_email=user_email,
+        custom_filename=custom_filename,
+    )
+    _allocations[upload_id] = alloc
+    _session_index[key] = upload_id
+
+    try:
+        start_cleanup_task()
+    except RuntimeError:
+        pass
+    return alloc
+
+
+def get_allocation(upload_id: str) -> Optional[_Allocation]:
+    return _allocations.get(upload_id)
+
+
+def find_allocation_by_path(session_id: str, client_path: str) -> Optional[_Allocation]:
+    """Look up an allocation by (session_id, client_path)."""
+    upload_id = _session_index.get((session_id, client_path))
+    if not upload_id:
+        return None
+    return _allocations.get(upload_id)
+
+
+def generate_upload_url(
+    base_url: str,
+    upload_id: str,
+    ttl_seconds: int,
+) -> tuple[str, int]:
+    """Generate a signed PUT URL for a staged upload allocation.
+
+    Returns:
+        (url, exp_timestamp)
+    """
+    exp = int(time.time()) + ttl_seconds
+    params = {
+        "uid": upload_id,
+        "exp": str(exp),
+    }
+    params["sig"] = _compute_signature(params)
+    base = base_url.rstrip("/")
+    return f"{base}/drive-upload?{urlencode(params)}", exp
+
+
+def verify_upload_url(upload_id: str, exp: str, sig: str) -> tuple[bool, str]:
+    """Verify PUT-URL signature, expiry, and one-time use.
+
+    Returns ``(is_valid, error_message)``. On success, the upload_id is
+    marked consumed so a second PUT to the same URL is rejected.
+    """
+    params = {"uid": upload_id, "exp": exp}
+    expected = _compute_signature(params)
+    if not _hmac.compare_digest(sig, expected):
+        return False, "Invalid signature"
+
+    try:
+        exp_ts = int(exp)
+    except (ValueError, TypeError):
+        return False, "Invalid expiry"
+
+    if time.time() > exp_ts:
+        return False, "Upload link has expired"
+
+    if _consumed_uploads.is_consumed_sync(upload_id):
+        return False, "Upload URL already used"
+
+    if upload_id not in _allocations:
+        return False, "Unknown upload id"
+
+    _consumed_uploads.consume_sync(upload_id)
+    return True, ""
+
+
+def staged_path(upload_id: str) -> str:
+    """Return the on-disk path where bytes for this upload are stored."""
+    temp_dir = _get_temp_dir()
+    alloc = _allocations.get(upload_id)
+    suffix = alloc.filename if alloc else "upload"
+    safe_suffix = os.path.basename(suffix).replace("/", "_") or "upload"
+    return os.path.join(temp_dir, f"{upload_id}_{safe_suffix}")
+
+
+def mark_received(upload_id: str, byte_count: int) -> None:
+    alloc = _allocations.get(upload_id)
+    if alloc:
+        alloc.received = True
+        logger.info(
+            "Drive upload staged: %s (%d bytes) for %s",
+            upload_id[:8],
+            byte_count,
+            alloc.user_email,
+        )
+
+
+def read_staged_bytes(upload_id: str) -> Optional[bytes]:
+    """Read the staged bytes for a finalized upload."""
+    alloc = _allocations.get(upload_id)
+    if not alloc or not alloc.received:
+        return None
+    path = staged_path(upload_id)
+    resolved = os.path.realpath(path)
+    temp_dir = os.path.realpath(_get_temp_dir())
+    if not resolved.startswith(temp_dir):
+        return None
+    if not os.path.exists(resolved):
+        return None
+    with open(resolved, "rb") as f:
+        return f.read()
+
+
+def consume_allocation(upload_id: str) -> None:
+    """Remove allocation, session-index entry, and on-disk file."""
+    alloc = _allocations.pop(upload_id, None)
+    if alloc:
+        _session_index.pop((alloc.session_id, alloc.client_path), None)
+    path = staged_path(upload_id)
+    try:
+        if os.path.exists(path):
+            os.unlink(path)
+    except OSError as e:
+        logger.warning("Failed to clean up staged upload %s: %s", upload_id[:8], e)
+
+
+def _evict_expired() -> int:
+    """Drop allocations + files older than the configured TTL."""
+    from config.settings import settings
+
+    ttl = settings.drive_upload_ttl_seconds
+    now = time.time()
+    expired = [
+        uid for uid, alloc in _allocations.items() if now - alloc.allocated_at > ttl
+    ]
+    for uid in expired:
+        consume_allocation(uid)
+    if expired:
+        logger.info(
+            "Drive upload cleanup: removed %d expired allocations", len(expired)
+        )
+    return len(expired)
+
+
+async def _cleanup_loop() -> None:
+    while True:
+        try:
+            await asyncio.sleep(CLEANUP_INTERVAL_SECONDS)
+            _evict_expired()
+        except asyncio.CancelledError:
+            break
+        except Exception as e:
+            logger.warning("Drive upload cleanup error: %s", e)
+
+
+def start_cleanup_task() -> None:
+    """Start the background cleanup task (idempotent, no-op without a loop)."""
+    global _cleanup_task
+    if _cleanup_task is not None and not _cleanup_task.done():
+        return
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    _cleanup_task = asyncio.create_task(_cleanup_loop())
+    logger.info("Drive upload cleanup task started")
+
+
+def reset_state() -> None:
+    """Clear state (for testing)."""
+    _consumed_uploads.clear()
+    _allocations.clear()
+    _session_index.clear()
+    global _hmac_key_cache
+    _hmac_key_cache = None
+
+
+__all__ = [
+    "allocate_upload",
+    "get_allocation",
+    "find_allocation_by_path",
+    "generate_upload_url",
+    "verify_upload_url",
+    "staged_path",
+    "mark_received",
+    "read_staged_bytes",
+    "consume_allocation",
+    "start_cleanup_task",
+    "reset_state",
+]

--- a/drive/upload_staging.py
+++ b/drive/upload_staging.py
@@ -193,33 +193,38 @@ def generate_upload_url(
     return f"{base}/drive-upload?{urlencode(params)}", exp
 
 
-def verify_upload_url(upload_id: str, exp: str, sig: str) -> tuple[bool, str]:
+def verify_upload_url(
+    upload_id: str, exp: str, sig: str
+) -> tuple[bool, str, Optional[_Allocation]]:
     """Verify PUT-URL signature, expiry, and one-time use.
 
-    Returns ``(is_valid, error_message)``. On success, the upload_id is
-    marked consumed so a second PUT to the same URL is rejected.
+    Returns ``(is_valid, error_message, allocation)``. The allocation
+    reference is captured *before* the token is consumed, so a TTL
+    eviction firing between this call and the endpoint's use of the
+    allocation cannot strand a consumed token without an allocation.
     """
     params = {"uid": upload_id, "exp": exp}
     expected = _compute_signature(params)
     if not _hmac.compare_digest(sig, expected):
-        return False, "Invalid signature"
+        return False, "Invalid signature", None
 
     try:
         exp_ts = int(exp)
     except (ValueError, TypeError):
-        return False, "Invalid expiry"
+        return False, "Invalid expiry", None
 
     if time.time() > exp_ts:
-        return False, "Upload link has expired"
+        return False, "Upload link has expired", None
 
     if _consumed_uploads.is_consumed_sync(upload_id):
-        return False, "Upload URL already used"
+        return False, "Upload URL already used", None
 
-    if upload_id not in _allocations:
-        return False, "Unknown upload id"
+    alloc = _allocations.get(upload_id)
+    if alloc is None:
+        return False, "Unknown upload id", None
 
     _consumed_uploads.consume_sync(upload_id)
-    return True, ""
+    return True, "", alloc
 
 
 def staged_path(upload_id: str) -> str:

--- a/drive/upload_tools.py
+++ b/drive/upload_tools.py
@@ -653,14 +653,14 @@ def setup_drive_tools(mcp: FastMCP) -> None:
     @mcp.tool(
         name="upload_to_drive",
         description=(
-            "Upload a file to Google Drive. When DRIVE_UPLOAD_CLIENT_FS=true "
-            "(default) and the server is remote, `path` refers to the *client's* "
-            "filesystem: the first call returns a pendingUpload payload with a "
-            "signed PUT URL; the client uploads bytes to that URL, then re-calls "
-            "this tool with the same path to finalize the Drive upload. When "
-            "DRIVE_UPLOAD_CLIENT_FS=false, `path` is the server's local "
-            "filesystem (legacy single-call behavior). Folder uploads are only "
-            "supported in legacy mode."
+            "Upload a file to Google Drive. By default `path` is the server's "
+            "local filesystem (single call, supports folders). On remote "
+            "deployments where the client and server are on different machines, "
+            "set DRIVE_UPLOAD_CLIENT_FS=true: `path` is then the *client's* "
+            "filesystem — the first call returns a pendingUpload payload with "
+            "a signed PUT URL; the client uploads bytes to that URL, then "
+            "re-calls this tool with the same path to finalize the Drive "
+            "upload. Folder uploads are only supported in server-FS mode."
         ),
         tags={"upload", "drive", "file", "folder", "storage", "google", "unified"},
         annotations={

--- a/drive/upload_tools.py
+++ b/drive/upload_tools.py
@@ -652,7 +652,16 @@ def setup_drive_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(
         name="upload_to_drive",
-        description="Upload a local file or folder to Google Drive with UNIFIED authentication (no email parameter needed when authenticated via GoogleProvider)",
+        description=(
+            "Upload a file to Google Drive. When DRIVE_UPLOAD_CLIENT_FS=true "
+            "(default) and the server is remote, `path` refers to the *client's* "
+            "filesystem: the first call returns a pendingUpload payload with a "
+            "signed PUT URL; the client uploads bytes to that URL, then re-calls "
+            "this tool with the same path to finalize the Drive upload. When "
+            "DRIVE_UPLOAD_CLIENT_FS=false, `path` is the server's local "
+            "filesystem (legacy single-call behavior). Folder uploads are only "
+            "supported in legacy mode."
+        ),
         tags={"upload", "drive", "file", "folder", "storage", "google", "unified"},
         annotations={
             "title": "Google Drive File/Folder Upload (Unified Auth)",
@@ -871,6 +880,11 @@ async def _handle_client_fs_upload(
     existing ``upload_content_to_drive_api`` and return the normal
     ``UploadFileResponse`` with ``fileInfo``. On success the staging
     record is consumed.
+
+    Phase-2 ``folder_id`` and ``filename`` override the values captured at
+    Phase 1 if the caller passes them on the second call (so a user can
+    re-target the destination folder after PUT-ing the bytes). If the
+    caller passes the defaults, Phase-1 values are used.
     """
     from auth.context import get_session_context
 
@@ -911,12 +925,22 @@ async def _handle_client_fs_upload(
                 ),
             )
 
+        # Honor Phase-2 overrides when the caller passes non-default values.
+        # `folder_id="root"` is the default, so we treat it as "not set"
+        # unless it differs from the Phase-1 value.
+        effective_folder_id = (
+            folder_id if folder_id and folder_id != "root" else existing.folder_id
+        )
+        effective_filename = (
+            custom_filename or existing.custom_filename or existing.filename
+        )
+
         drive_service = await get_service("drive", user_email)
         result = await upload_content_to_drive_api(
             service=drive_service,
             content=staged,
-            filename=existing.custom_filename or existing.filename,
-            folder_id=existing.folder_id,
+            filename=effective_filename,
+            folder_id=effective_folder_id,
             mime_type=existing.mime_type,
         )
 
@@ -926,7 +950,7 @@ async def _handle_client_fs_upload(
             "filePath": path,
             "fileSize": len(staged),
             "mimeType": result.get("mimeType", existing.mime_type),
-            "folderId": existing.folder_id,
+            "folderId": effective_folder_id,
             "driveUrl": f"https://drive.google.com/file/d/{result['id']}/view",
             "webViewLink": result.get(
                 "webViewLink",

--- a/drive/upload_tools.py
+++ b/drive/upload_tools.py
@@ -59,10 +59,15 @@ from .upload_types import (
     CheckAuthResponse,
     FileUploadInfo,
     FolderUploadSummary,
+    PendingUploadInfo,
     StartAuthResponse,
     UploadFileResponse,
 )
-from .utils import DriveUploadError, upload_file_to_drive_api
+from .utils import (
+    DriveUploadError,
+    upload_content_to_drive_api,
+    upload_file_to_drive_api,
+)
 
 # Default services — derived from the catalog (all non-required services).
 DEFAULT_SERVICES = ScopeRegistry.get_default_services()
@@ -735,6 +740,38 @@ def setup_drive_tools(mcp: FastMCP) -> None:
             f"Upload request: {path} -> Drive folder {folder_id} for {user_google_email}"
         )
 
+        # ── Client-filesystem mode ───────────────────────────────────────
+        # When enabled, `path` is on the client's filesystem (not the
+        # server's). We orchestrate transport via an HMAC-signed PUT URL.
+        # Phase 1: no staged bytes → return upload instructions.
+        # Phase 2: staged bytes present → finalize Drive upload.
+        if settings.drive_upload_client_fs:
+            try:
+                return await _handle_client_fs_upload(
+                    path=path,
+                    folder_id=folder_id,
+                    custom_filename=filename,
+                    user_email=user_google_email,
+                )
+            except GoogleAuthError as e:
+                error_msg = f"Authentication error: {e}"
+                logger.error(f"❌ {error_msg}")
+                return UploadFileResponse(
+                    success=False,
+                    userEmail=user_google_email,
+                    message="",
+                    error=error_msg,
+                )
+            except Exception as e:
+                error_msg = f"Client-FS upload error: {e}"
+                logger.error(f"❌ {error_msg}", exc_info=True)
+                return UploadFileResponse(
+                    success=False,
+                    userEmail=user_google_email,
+                    message="",
+                    error=error_msg,
+                )
+
         try:
             # Validate and convert path
             local_path = Path(path).expanduser().resolve()
@@ -817,6 +854,137 @@ def setup_drive_tools(mcp: FastMCP) -> None:
             return UploadFileResponse(
                 success=False, userEmail=user_google_email, message="", error=error_msg
             )
+
+
+async def _handle_client_fs_upload(
+    path: str,
+    folder_id: str,
+    custom_filename: Optional[str],
+    user_email: str,
+) -> UploadFileResponse:
+    """Two-phase client→server→Drive upload, no extra tool parameters.
+
+    Phase 1 (allocation): no staged bytes for ``(session_id, path)`` →
+    allocate, sign a PUT URL, return ``pendingUpload`` instructions.
+
+    Phase 2 (finalize): staged bytes present → run them through the
+    existing ``upload_content_to_drive_api`` and return the normal
+    ``UploadFileResponse`` with ``fileInfo``. On success the staging
+    record is consumed.
+    """
+    from auth.context import get_session_context
+
+    from .upload_staging import (
+        allocate_upload,
+        consume_allocation,
+        find_allocation_by_path,
+        generate_upload_url,
+        read_staged_bytes,
+    )
+
+    session_id = await get_session_context()
+    if not session_id:
+        return UploadFileResponse(
+            success=False,
+            userEmail=user_email,
+            message="",
+            error=(
+                "Client-filesystem upload mode requires an MCP session "
+                "(none found in current context). Set DRIVE_UPLOAD_CLIENT_FS=false "
+                "for stdio / local-filesystem uploads."
+            ),
+        )
+
+    # Phase 2: staged bytes already present for this (session, path) pair
+    existing = find_allocation_by_path(session_id, path)
+    if existing and existing.received:
+        staged = read_staged_bytes(existing.upload_id)
+        if staged is None:
+            consume_allocation(existing.upload_id)
+            return UploadFileResponse(
+                success=False,
+                userEmail=user_email,
+                message="",
+                error=(
+                    "Staged upload could not be read from disk. Re-call "
+                    "upload_to_drive to retry the transfer."
+                ),
+            )
+
+        drive_service = await get_service("drive", user_email)
+        result = await upload_content_to_drive_api(
+            service=drive_service,
+            content=staged,
+            filename=existing.custom_filename or existing.filename,
+            folder_id=existing.folder_id,
+            mime_type=existing.mime_type,
+        )
+
+        file_info: FileUploadInfo = {
+            "fileId": result["id"],
+            "fileName": result["name"],
+            "filePath": path,
+            "fileSize": len(staged),
+            "mimeType": result.get("mimeType", existing.mime_type),
+            "folderId": existing.folder_id,
+            "driveUrl": f"https://drive.google.com/file/d/{result['id']}/view",
+            "webViewLink": result.get(
+                "webViewLink",
+                f"https://drive.google.com/file/d/{result['id']}/view",
+            ),
+        }
+
+        consume_allocation(existing.upload_id)
+        logger.info(
+            f"Client-FS upload finalized: {result['name']} (ID: {result['id']})"
+        )
+        return UploadFileResponse(
+            success=True,
+            userEmail=user_email,
+            fileInfo=file_info,
+            message=f"Successfully uploaded {result['name']} to Google Drive",
+        )
+
+    # Phase 1: allocate + return signed PUT URL
+    alloc = allocate_upload(
+        session_id=session_id,
+        client_path=path,
+        user_email=user_email,
+        folder_id=folder_id,
+        custom_filename=custom_filename,
+    )
+    ttl = settings.drive_upload_ttl_seconds
+    url, exp_ts = generate_upload_url(settings.base_url, alloc.upload_id, ttl)
+
+    safe_path = path.replace('"', '\\"')
+    curl_example = f'curl -X PUT --data-binary @"{safe_path}" "{url}"'
+
+    pending: PendingUploadInfo = {
+        "uploadId": alloc.upload_id,
+        "uploadUrl": url,
+        "method": "PUT",
+        "expiresAt": exp_ts,
+        "expiresInSeconds": ttl,
+        "maxSizeBytes": settings.drive_upload_max_size_mb * 1024 * 1024,
+        "instructions": [
+            f"PUT the bytes of '{path}' to the upload URL (single request).",
+            f"Then re-invoke upload_to_drive with path='{path}' to finalize.",
+            "The URL is one-time-use and expires; a fresh tool call always "
+            "issues a new URL.",
+        ],
+        "curlExample": curl_example,
+    }
+
+    return UploadFileResponse(
+        success=False,
+        userEmail=user_email,
+        message=(
+            "Upload pending: client filesystem mode is active. "
+            f"PUT '{path}' to the provided uploadUrl, then re-call this tool "
+            "with the same path to finalize the Drive upload."
+        ),
+        pendingUpload=pending,
+    )
 
 
 async def _upload_folder_to_drive(

--- a/drive/upload_types.py
+++ b/drive/upload_types.py
@@ -35,6 +35,26 @@ class FolderUploadSummary(TypedDict):
     uploadDuration: float
 
 
+class PendingUploadInfo(TypedDict, total=False):
+    """Instructions returned to the client when an upload needs to be staged.
+
+    Emitted by ``upload_to_drive`` in client-filesystem mode (see
+    ``settings.drive_upload_client_fs``). The client (typically an
+    LLM agent with shell access) is expected to PUT the file's bytes
+    to ``uploadUrl``, then re-invoke ``upload_to_drive`` with the same
+    ``path`` to finalize the Drive upload.
+    """
+
+    uploadId: str
+    uploadUrl: str
+    method: str  # always "PUT"
+    expiresAt: int  # unix timestamp
+    expiresInSeconds: int
+    maxSizeBytes: int
+    instructions: List[str]
+    curlExample: str
+
+
 class UploadFileResponse(TypedDict, total=False):
     """Response structure for upload_file_to_drive and upload_file_to_drive_unified tools."""
 
@@ -46,6 +66,7 @@ class UploadFileResponse(TypedDict, total=False):
     message: str
     error: Optional[str]
     warnings: Optional[List[str]]  # For partial failures in folder upload
+    pendingUpload: Optional[PendingUploadInfo]  # Phase 1 of client-FS upload
 
 
 class OAuthInstruction(TypedDict):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "google-workspace-unlimited"
-version = "2.1.0"
+version = "2.2.0"
 description = "Comprehensive MCP server for Google Workspace integration - 72+ tools across Gmail, Drive, Docs, Sheets, Slides, Calendar, Forms, Chat, and Photos with OAuth 2.1 + PKCE authentication"
 readme = "README.md"
 license = "Apache-2.0"

--- a/server.py
+++ b/server.py
@@ -573,6 +573,16 @@ from tools.attachment_endpoints import setup_attachment_endpoints
 setup_attachment_endpoints(mcp)
 logger.info("Attachment download endpoint registered (/attachment-download)")
 
+# Setup Drive upload endpoint (client→server transport for upload_to_drive)
+if settings.drive_upload_client_fs:
+    from tools.drive_upload_endpoints import setup_drive_upload_endpoints
+
+    setup_drive_upload_endpoints(mcp)
+    logger.info(
+        "Drive upload endpoint registered (PUT /drive-upload) — "
+        "client-filesystem mode active"
+    )
+
 # Attachment cleanup task is started lazily on first download or via lifespan
 # (asyncio.create_task requires a running event loop, so defer to runtime)
 

--- a/tools/drive_upload_endpoints.py
+++ b/tools/drive_upload_endpoints.py
@@ -1,0 +1,123 @@
+"""HTTP endpoint for receiving client→server file uploads via signed URLs.
+
+Inverse of ``/attachment-download``. Registered by
+``setup_drive_upload_endpoints(mcp)`` in ``server.py``. Active when
+``settings.drive_upload_client_fs`` is enabled.
+
+Flow:
+    1. ``upload_to_drive`` tool allocates an upload + signs a PUT URL.
+    2. Client streams file bytes via ``PUT /drive-upload?uid=...&exp=...&sig=...``.
+    3. Tool is re-invoked with the same ``path`` and finalizes the Drive upload
+       from the staged bytes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp import FastMCP
+
+from config.enhanced_logging import setup_logger
+
+logger = setup_logger()
+
+
+def setup_drive_upload_endpoints(mcp: FastMCP) -> None:
+    """Register the ``PUT /drive-upload`` HTTP endpoint."""
+
+    @mcp.custom_route("/drive-upload", methods=["PUT"])
+    async def drive_upload(request: Any):
+        from starlette.responses import JSONResponse
+
+        from config.settings import settings
+        from drive.upload_staging import (
+            get_allocation,
+            mark_received,
+            staged_path,
+            verify_upload_url,
+        )
+
+        query = dict(request.query_params)
+        upload_id = query.get("uid", "")
+        exp = query.get("exp", "")
+        sig = query.get("sig", "")
+
+        if not all([upload_id, exp, sig]):
+            return JSONResponse(
+                {"error": "Missing required query parameters (uid, exp, sig)"},
+                status_code=400,
+            )
+
+        valid, error = verify_upload_url(upload_id, exp, sig)
+        if not valid:
+            status = (
+                410
+                if "expired" in error.lower() or "already used" in error.lower()
+                else 403
+            )
+            return JSONResponse({"error": error}, status_code=status)
+
+        alloc = get_allocation(upload_id)
+        if alloc is None:
+            return JSONResponse({"error": "Allocation not found"}, status_code=404)
+
+        max_bytes = settings.drive_upload_max_size_mb * 1024 * 1024
+        target = staged_path(upload_id)
+
+        # Stream the request body to disk to avoid loading large files in memory.
+        # Enforce max-size during streaming.
+        total = 0
+        try:
+            with open(target, "wb") as f:
+                async for chunk in request.stream():
+                    if not chunk:
+                        continue
+                    total += len(chunk)
+                    if total > max_bytes:
+                        try:
+                            import os
+
+                            f.close()
+                            os.unlink(target)
+                        except OSError:
+                            pass
+                        return JSONResponse(
+                            {
+                                "error": (
+                                    f"Upload exceeds max size "
+                                    f"({settings.drive_upload_max_size_mb} MB)"
+                                )
+                            },
+                            status_code=413,
+                        )
+                    f.write(chunk)
+        except Exception as e:
+            logger.error("Drive upload write failed: %s", e, exc_info=True)
+            return JSONResponse(
+                {"error": f"Failed to write staged upload: {e}"}, status_code=500
+            )
+
+        if total == 0:
+            try:
+                import os
+
+                os.unlink(target)
+            except OSError:
+                pass
+            return JSONResponse({"error": "Empty body"}, status_code=400)
+
+        mark_received(upload_id, total)
+
+        return JSONResponse(
+            {
+                "status": "received",
+                "uploadId": upload_id,
+                "bytes": total,
+                "filename": alloc.filename,
+                "nextStep": (
+                    "Re-invoke upload_to_drive with the same path to finalize "
+                    "the Drive upload."
+                ),
+            },
+            status_code=200,
+        )

--- a/tools/drive_upload_endpoints.py
+++ b/tools/drive_upload_endpoints.py
@@ -31,7 +31,6 @@ def setup_drive_upload_endpoints(mcp: FastMCP) -> None:
 
         from config.settings import settings
         from drive.upload_staging import (
-            get_allocation,
             mark_received,
             staged_path,
             verify_upload_url,
@@ -48,18 +47,17 @@ def setup_drive_upload_endpoints(mcp: FastMCP) -> None:
                 status_code=400,
             )
 
-        valid, error = verify_upload_url(upload_id, exp, sig)
-        if not valid:
+        # verify_upload_url atomically returns the allocation alongside the
+        # validity check, so a TTL eviction between verify and use cannot
+        # strand a consumed token without its allocation record.
+        valid, error, alloc = verify_upload_url(upload_id, exp, sig)
+        if not valid or alloc is None:
             status = (
                 410
                 if "expired" in error.lower() or "already used" in error.lower()
                 else 403
             )
             return JSONResponse({"error": error}, status_code=status)
-
-        alloc = get_allocation(upload_id)
-        if alloc is None:
-            return JSONResponse({"error": "Allocation not found"}, status_code=404)
 
         max_bytes = settings.drive_upload_max_size_mb * 1024 * 1024
         target = staged_path(upload_id)


### PR DESCRIPTION
## Summary
- Adds `DRIVE_UPLOAD_CLIENT_FS` (default `true`): when set, `upload_to_drive` treats `path` as a *client* filesystem path and orchestrates client→server→Drive transport via an HMAC-signed PUT URL — without changing the tool signature
- Inverse of the existing email-attachment download flow: same HKDF + `ConsumedTokenStore` primitives, distinct HKDF `info` (`b\"drive-upload-hmac-v1\"`), new `PUT /drive-upload` endpoint streams bytes to a `0o700` temp dir with TTL cleanup
- Set `DRIVE_UPLOAD_CLIENT_FS=false` to keep the legacy server-local-path behavior for stdio / co-located use

## How clients use it
1. Client calls `upload_to_drive(path=\"/Users/me/foo.pdf\", folder_id=\"...\")` — same call as today.
2. Server returns `success: false` with `pendingUpload: { uploadUrl, uploadId, expiresAt, method: \"PUT\", maxSizeBytes, instructions, curlExample }`.
3. Client PUTs file bytes to the signed URL (curl example provided in the response).
4. Client re-calls `upload_to_drive` with the same `path` — server finds staged bytes via `(session_id, client_path)` lookup, finalizes through the existing `upload_content_to_drive_api()`, returns the standard `fileInfo` response.

## Files
- `config/settings.py` — `drive_upload_client_fs`, `drive_upload_temp_dir`, `drive_upload_max_size_mb` (100 MB), `drive_upload_ttl_seconds` (900s)
- `drive/upload_staging.py` (new) — allocation registry, HMAC sign/verify, TTL cleanup
- `drive/upload_types.py` — adds `PendingUploadInfo`, optional `pendingUpload` field on `UploadFileResponse`
- `drive/upload_tools.py` — `upload_to_drive` branches on the env var; new `_handle_client_fs_upload` two-phase helper
- `tools/drive_upload_endpoints.py` (new) — `PUT /drive-upload?uid=&exp=&sig=`, streams body to disk, enforces max size during streaming
- `server.py` — registers `setup_drive_upload_endpoints(mcp)` (gated on the same setting)

## Test plan
- [ ] Unit: HMAC sign/verify roundtrip, tampered-sig rejection, one-time-use enforcement, `(session_id, path)` allocation lookup (already smoke-tested locally; pending suite)
- [ ] Live: against the running prod remote, call `upload_to_drive` with a client path, PUT the bytes via the returned URL, re-call to finalize, verify the file lands in Drive
- [ ] Negative: tampered signature → 403; expired URL → 410; second PUT to same URL → 410; payload >100 MB → 413; empty body → 400
- [ ] Legacy: set `DRIVE_UPLOAD_CLIENT_FS=false` and confirm server-local-path uploads still work end-to-end
- [ ] Cleanup task evicts allocations + temp files past TTL

🤖 Generated with [Claude Code](https://claude.com/claude-code)