### PR TITLE
Fix OAuth 400 invalid_request: separate Photos scopes from the combined flow, drop retired photoslibrary scopes

### DIFF
--- a/auth/compatibility_shim.py
+++ b/auth/compatibility_shim.py
@@ -124,8 +124,12 @@ class CompatibilityShim:
             # Slides legacy names
             "slides": ScopeRegistry.GOOGLE_API_SCOPES["slides"]["full"],
             "slides_read": ScopeRegistry.GOOGLE_API_SCOPES["slides"]["readonly"],
-            # Photos legacy names (using only valid scopes)
-            "photos_read": ScopeRegistry.GOOGLE_API_SCOPES["photos"]["readonly"],
+            # Photos legacy names. The broad photoslibrary/photoslibrary.readonly
+            # scopes were retired by Google after March 31, 2025, so the legacy
+            # "read" names now map to the app-created-data readonly scope.
+            "photos_read": ScopeRegistry.GOOGLE_API_SCOPES["photos"][
+                "readonly_appcreated"
+            ],
             "photos_append": ScopeRegistry.GOOGLE_API_SCOPES["photos"]["appendonly"],
             "photos_readonly_appcreated": ScopeRegistry.GOOGLE_API_SCOPES["photos"][
                 "readonly_appcreated"
@@ -134,7 +138,9 @@ class CompatibilityShim:
                 "edit_appcreated"
             ],
             # PhotosLibrary legacy names (for backwards compatibility)
-            "photoslibrary_read": ScopeRegistry.GOOGLE_API_SCOPES["photos"]["readonly"],
+            "photoslibrary_read": ScopeRegistry.GOOGLE_API_SCOPES["photos"][
+                "readonly_appcreated"
+            ],
             "photoslibrary_append": ScopeRegistry.GOOGLE_API_SCOPES["photos"][
                 "appendonly"
             ],
@@ -249,14 +255,22 @@ class CompatibilityShim:
                 "description": "Google Slides service",
             },
             "photos": {
-                "default_scopes": ["photos_read", "photos_append"],
+                "default_scopes": [
+                    "photos_append",
+                    "photos_readonly_appcreated",
+                    "photos_edit_appcreated",
+                ],
                 "version": "v1",
-                "description": "Google Photos service",
+                "description": "Google Photos service (app-created data only)",
             },
             "photoslibrary": {
-                "default_scopes": ["photos_read", "photos_append"],
+                "default_scopes": [
+                    "photos_append",
+                    "photos_readonly_appcreated",
+                    "photos_edit_appcreated",
+                ],
                 "version": "v1",
-                "description": "Google Photos Library API service",
+                "description": "Google Photos Library API service (app-created data only)",
             },
             "tasks": {
                 "default_scopes": ["tasks_read", "tasks_full"],

--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -1169,8 +1169,9 @@ async def initiate_oauth_flow(
         logger.info("🔑 INITIATE: Using default OAuth configuration")
 
     # Verify no problematic scopes are included
+    from .scope_registry import ScopeRegistry
+
     problematic_patterns = [
-        "photoslibrary.sharing",
         "cloud-platform",
         "cloudfunctions",
         "pubsub",
@@ -1180,16 +1181,33 @@ async def initiate_oauth_flow(
         scope
         for scope in oauth_scopes
         if any(bad in scope for bad in problematic_patterns)
+        or scope in ScopeRegistry.RETIRED_SCOPES
     ]
 
-    if problematic_scopes:
+    # Google rejects authorization requests mixing Photos Library scopes with
+    # other Google API scopes (400 invalid_request). A photos-only flow is
+    # fine; a mixed one is not.
+    photos_scopes = [s for s in oauth_scopes if "auth/photoslibrary" in s]
+    non_photos_api_scopes = [
+        s
+        for s in oauth_scopes
+        if "auth/photoslibrary" not in s
+        and s not in ScopeRegistry.GOOGLE_API_SCOPES["base"].values()
+    ]
+    if photos_scopes and non_photos_api_scopes:
         logger.error(
-            f"Found {len(problematic_scopes)} problematic scopes in oauth_comprehensive"
+            f"Requesting {len(photos_scopes)} Photos scopes together with "
+            f"{len(non_photos_api_scopes)} other API scopes - Google will reject "
+            "this with 400 invalid_request. Photos requires its own OAuth flow "
+            "(selected_services=['photos'])."
         )
+
+    if problematic_scopes:
+        logger.error(f"Found {len(problematic_scopes)} problematic scopes")
         for scope in problematic_scopes:
             logger.error(f"Problematic scope: {scope}")
     else:
-        logger.info("✅ No problematic scopes found in oauth_comprehensive")
+        logger.info("✅ No problematic scopes found in requested OAuth scopes")
 
     # Create OAuth flow
     flow = Flow.from_client_config(

--- a/auth/scope_registry.py
+++ b/auth/scope_registry.py
@@ -135,13 +135,14 @@ class ScopeRegistry:
             "readonly": "https://www.googleapis.com/auth/presentations.readonly",
         },
         # Google Photos scopes
+        # The photoslibrary, photoslibrary.readonly, and photoslibrary.sharing
+        # scopes were retired by Google after March 31, 2025 and now return
+        # 403 PERMISSION_DENIED. Only app-created-data scopes remain, and the
+        # Library API only returns albums/media created by this app.
         "photos": {
-            "readonly": "https://www.googleapis.com/auth/photoslibrary.readonly",
             "appendonly": "https://www.googleapis.com/auth/photoslibrary.appendonly",
-            "full": "https://www.googleapis.com/auth/photoslibrary",
             "readonly_appcreated": "https://www.googleapis.com/auth/photoslibrary.readonly.appcreateddata",
             "edit_appcreated": "https://www.googleapis.com/auth/photoslibrary.edit.appcreateddata",
-            # Note: Added back 'full' scope - needed for album listing and search operations
         },
         # Google People API scopes
         "people": {
@@ -433,21 +434,24 @@ class ScopeRegistry:
             "slides.full",
             "slides.readonly",
         ],
+        # Photos scopes CANNOT be combined with Drive (or other Workspace)
+        # scopes in a single authorization request — Google's auth server
+        # rejects the mix with "Error 400: invalid_request — This request
+        # contains scopes that cannot be requested together". Photos must be
+        # authorized in its own OAuth flow (selected_services=["photos"]).
         "photos_basic": [
             "base.userinfo_email",
             "base.openid",
-            "photos.readonly",
             "photos.appendonly",
-            "photos.full",
-            # appcreateddata scopes excluded — restricts API to app-created content only
+            "photos.readonly_appcreated",
+            "photos.edit_appcreated",
         ],
         "photos_full": [
             "base.userinfo_email",
             "base.openid",
-            "photos.readonly",
             "photos.appendonly",
-            "photos.full",
-            # appcreateddata scopes excluded — restricts API to app-created content only
+            "photos.readonly_appcreated",
+            "photos.edit_appcreated",
         ],
         "tasks_basic": [
             "base.userinfo_email",
@@ -523,10 +527,10 @@ class ScopeRegistry:
             "forms.responses_readonly",
             "slides.full",
             "slides.readonly",
-            "photos.readonly",
-            "photos.appendonly",
-            "photos.full",
-            # appcreateddata scopes excluded — restricts API to app-created content only
+            # photos.* intentionally excluded: Google rejects authorization
+            # requests that combine photoslibrary scopes with Drive scopes
+            # (400 invalid_request). Photos requires its own OAuth flow —
+            # see SEPARATE_AUTH_SERVICES and the photos_basic group.
             "calendar.readonly",
             "calendar.events",
             "calendar.full",
@@ -537,6 +541,21 @@ class ScopeRegistry:
             "people.directory_readonly",
         ],
     }
+
+    # Scopes Google has removed entirely. Requesting them fails; API calls
+    # relying on them return 403 PERMISSION_DENIED. (Photos Library scopes
+    # retired after March 31, 2025.)
+    RETIRED_SCOPES = {
+        "https://www.googleapis.com/auth/photoslibrary",
+        "https://www.googleapis.com/auth/photoslibrary.readonly",
+        "https://www.googleapis.com/auth/photoslibrary.sharing",
+    }
+
+    # Services whose scopes Google refuses to combine with other services'
+    # scopes in a single authorization request (400 invalid_request:
+    # "This request contains scopes that cannot be requested together").
+    # These must be authorized in their own OAuth flow with their own token.
+    SEPARATE_AUTH_SERVICES = {"photos"}
 
     # Convenient access to individual service scope groups
     DRIVE_SCOPES = GOOGLE_API_SCOPES["drive"]
@@ -630,7 +649,10 @@ class ScopeRegistry:
                 )
             elif service == "photos":
                 result_scopes.extend(
-                    [service_scopes["readonly"], service_scopes["appendonly"]]
+                    [
+                        service_scopes["appendonly"],
+                        service_scopes["readonly_appcreated"],
+                    ]
                 )
             else:
                 # Default to readonly and full if available
@@ -745,6 +767,27 @@ class ScopeRegistry:
                 result.invalid_scopes.append(scope)
                 logger.warning(f"SCOPE_REGISTRY: Unknown scope: {scope}")
 
+        # Google rejects authorization requests mixing Photos Library scopes
+        # with any other Google API scopes (400 invalid_request)
+        photos_scopes = [s for s in scopes if "auth/photoslibrary" in s]
+        other_api_scopes = [
+            s
+            for s in scopes
+            if "auth/photoslibrary" not in s
+            and s not in cls.GOOGLE_API_SCOPES["base"].values()
+        ]
+        if photos_scopes and other_api_scopes:
+            result.is_valid = False
+            result.warnings.append(
+                "Photos Library scopes cannot be requested together with other "
+                "Google API scopes - Google returns 400 invalid_request. "
+                "Authorize Photos in a separate OAuth flow."
+            )
+            logger.error(
+                f"SCOPE_REGISTRY: Invalid combination - {len(photos_scopes)} Photos "
+                f"scopes mixed with {len(other_api_scopes)} other API scopes"
+            )
+
         # Check for missing base scopes
         base_scopes = cls.GOOGLE_API_SCOPES["base"]
         has_userinfo = base_scopes["userinfo_email"] in scopes
@@ -760,8 +803,9 @@ class ScopeRegistry:
             result.missing_scopes.append(base_scopes["openid"])
             result.warnings.append("Missing openid scope - OAuth flow may fail")
 
-        # Set overall validity
-        result.is_valid = len(result.invalid_scopes) == 0
+        # Set overall validity (preserve failures already recorded, e.g. the
+        # Photos/other-API mutual exclusion above)
+        result.is_valid = result.is_valid and len(result.invalid_scopes) == 0
 
         if result.is_valid:
             logger.info(
@@ -811,7 +855,7 @@ class ScopeRegistry:
             "docs_write": cls.GOOGLE_API_SCOPES["docs"]["full"],
             "sheets_read": cls.GOOGLE_API_SCOPES["sheets"]["readonly"],
             "sheets_write": cls.GOOGLE_API_SCOPES["sheets"]["full"],
-            "photos_read": cls.GOOGLE_API_SCOPES["photos"]["readonly"],
+            "photos_read": cls.GOOGLE_API_SCOPES["photos"]["readonly_appcreated"],
             "photos_append": cls.GOOGLE_API_SCOPES["photos"]["appendonly"],
             "tasks_read": cls.GOOGLE_API_SCOPES["tasks"]["readonly"],
             "tasks_full": cls.GOOGLE_API_SCOPES["tasks"]["full"],
@@ -908,9 +952,14 @@ class ScopeRegistry:
             },
             "photos": {
                 "name": "Google Photos",
-                "description": "Access and manage photos and albums",
+                "description": (
+                    "Upload photos and manage app-created albums. Requires a "
+                    "separate sign-in - Google does not allow Photos scopes in "
+                    "the same authorization as other services"
+                ),
                 "category": "Storage & Files",
                 "required": False,
+                "default_selected": False,
                 "scopes": cls.get_service_scopes("photos", "basic"),
             },
             "people": {
@@ -941,9 +990,32 @@ class ScopeRegistry:
 
     @classmethod
     def get_scopes_for_services(cls, service_keys: List[str]) -> List[str]:
-        """Get combined scopes for selected services."""
+        """
+        Get combined scopes for selected services.
+
+        Services in SEPARATE_AUTH_SERVICES (currently Photos) cannot share an
+        authorization request with other services — Google rejects the mix
+        with 400 invalid_request. When such a service is selected alongside
+        others, it is dropped from the combined request and must be
+        authorized in its own flow (e.g. selected_services=["photos"]).
+        """
         catalog = cls.get_service_catalog()
         all_scopes = set()
+
+        selected = [key for key in service_keys if key in catalog]
+        exclusive = [key for key in selected if key in cls.SEPARATE_AUTH_SERVICES]
+        combinable = [key for key in selected if key not in cls.SEPARATE_AUTH_SERVICES]
+
+        if exclusive and combinable:
+            logger.warning(
+                f"SCOPE_REGISTRY: {exclusive} cannot be authorized together with "
+                f"{combinable} - Google rejects the combined request "
+                f"(400 invalid_request). Dropping {exclusive} from this flow; "
+                f"authorize them separately (e.g. selected_services={exclusive})."
+            )
+        elif exclusive:
+            # Only exclusive service(s) selected - honor them
+            combinable = exclusive
 
         # Always include required services
         for service_key, service_info in catalog.items():
@@ -951,9 +1023,8 @@ class ScopeRegistry:
                 all_scopes.update(service_info["scopes"])
 
         # Add selected services
-        for key in service_keys:
-            if key in catalog:
-                all_scopes.update(catalog[key]["scopes"])
+        for key in combinable:
+            all_scopes.update(catalog[key]["scopes"])
 
         return list(all_scopes)
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -764,13 +764,12 @@ class Settings(BaseSettings):
         "https://www.googleapis.com/auth/calendar.readonly",
         "https://www.googleapis.com/auth/calendar.events",
         "https://www.googleapis.com/auth/calendar",
-        # Google Photos Library API scopes
-        "https://www.googleapis.com/auth/photoslibrary.readonly",
-        "https://www.googleapis.com/auth/photoslibrary.appendonly",
-        "https://www.googleapis.com/auth/photoslibrary",
-        "https://www.googleapis.com/auth/photoslibrary.sharing",
-        "https://www.googleapis.com/auth/photoslibrary.readonly.appcreateddata",
-        "https://www.googleapis.com/auth/photoslibrary.edit.appcreateddata",
+        # Google Photos Library API scopes intentionally excluded:
+        # Google rejects authorization requests that combine photoslibrary
+        # scopes with Drive scopes (400 invalid_request), and the broad
+        # photoslibrary / photoslibrary.readonly / photoslibrary.sharing
+        # scopes were retired after March 31, 2025. Photos must be
+        # authorized via its own OAuth flow (selected_services=["photos"]).
         # Cloud Platform scopes (for broader Google services)
         "https://www.googleapis.com/auth/cloud-platform",
         "https://www.googleapis.com/auth/cloudfunctions",
@@ -798,9 +797,12 @@ class Settings(BaseSettings):
                 f"SCOPE_DEBUG: Retrieved {len(scopes)} scopes from oauth_comprehensive group"
             )
 
-            # Verify no problematic scopes are included
+            # Verify no problematic scopes are included. Any photoslibrary
+            # scope is problematic here: this combined bundle includes Drive
+            # scopes, and Google rejects requests mixing Photos and Drive
+            # scopes (400 invalid_request).
             problematic_patterns = [
-                "photoslibrary.sharing",
+                "photoslibrary",
                 "cloud-platform",
                 "cloudfunctions",
                 "pubsub",
@@ -810,6 +812,7 @@ class Settings(BaseSettings):
                 scope
                 for scope in scopes
                 if any(bad in scope for bad in problematic_patterns)
+                or scope in ScopeRegistry.RETIRED_SCOPES
             ]
 
             if problematic_scopes:

--- a/photos/README.md
+++ b/photos/README.md
@@ -2,6 +2,27 @@
 
 This document describes the Google Photos API integration following FastMCP2 patterns and optimization best practices.
 
+> **⚠️ Important — Google Photos API changes (effective March 31, 2025)**
+>
+> 1. **Retired scopes**: `photoslibrary`, `photoslibrary.readonly`, and
+>    `photoslibrary.sharing` were removed by Google. Requests using them return
+>    `403 PERMISSION_DENIED`. Only `photoslibrary.appendonly`,
+>    `photoslibrary.readonly.appcreateddata`, and
+>    `photoslibrary.edit.appcreateddata` remain.
+> 2. **App-created data only**: listing and search now only return albums and
+>    media items **created by this app** (i.e., uploaded via these tools).
+>    Tools like `search_photos`, `list_photos_albums`, `photos_smart_search`,
+>    and `photos_batch_details` cannot see the rest of the user's library.
+>    Library-wide selection requires Google's interactive
+>    [Picker API](https://developers.google.com/photos/picker/guides/get-started-picker),
+>    which is not yet integrated.
+> 3. **Separate authorization required**: Google rejects any OAuth request
+>    that combines Photos Library scopes with Drive (or other Workspace)
+>    scopes — `Error 400: invalid_request — This request contains scopes that
+>    cannot be requested together`. Photos is therefore excluded from the
+>    combined `oauth_comprehensive` flow and must be authorized on its own
+>    (e.g., `selected_services=["photos"]`).
+
 ## Overview
 
 The Google Photos integration provides:
@@ -44,14 +65,18 @@ photos/
 
 ## Google Photos API Scopes
 
-The integration supports all Google Photos API scopes:
+The integration uses the Photos Library API scopes that remain valid after
+Google's March 31, 2025 changes:
 
 | Scope Key | URL | Description |
 |-----------|-----|-------------|
-| `photos.readonly` | `https://www.googleapis.com/auth/photoslibrary.readonly` | Read-only access to photos |
-| `photos.appendonly` | `https://www.googleapis.com/auth/photoslibrary.appendonly` | Add photos only |
-| `photos.full` | `https://www.googleapis.com/auth/photoslibrary` | Full access to photos |
-| `photos.sharing` | `https://www.googleapis.com/auth/photoslibrary.sharing` | Manage photo sharing |
+| `photos.appendonly` | `https://www.googleapis.com/auth/photoslibrary.appendonly` | Upload photos and create albums |
+| `photos.readonly_appcreated` | `https://www.googleapis.com/auth/photoslibrary.readonly.appcreateddata` | Read app-created albums/media |
+| `photos.edit_appcreated` | `https://www.googleapis.com/auth/photoslibrary.edit.appcreateddata` | Edit app-created albums/media |
+
+Retired scopes (`photoslibrary`, `photoslibrary.readonly`,
+`photoslibrary.sharing`) are tracked in `ScopeRegistry.RETIRED_SCOPES` and are
+never requested.
 
 ## Standard MCP Tools
 

--- a/photos/photos_tools.py
+++ b/photos/photos_tools.py
@@ -57,19 +57,14 @@ async def _get_photos_service_with_fallback(user_google_email: str):
     from auth.compatibility_shim import CompatibilityShim
     from auth.service_manager import get_google_service
 
-    # Get photos scopes - MUST include app-created data scopes for API to work
+    # Get photos scopes. Only the app-created-data scopes survive Google's
+    # March 31, 2025 Photos Library API changes - the broad photoslibrary
+    # and photoslibrary.readonly scopes were retired and now return
+    # 403 PERMISSION_DENIED. Listing/search only returns app-created content.
     try:
         shim = CompatibilityShim()
         scope_groups = shim.get_legacy_scope_groups()
-        # Use both general and app-created data scopes for full access
         photos_scopes = [
-            scope_groups.get(
-                "photoslibrary_read",
-                "https://www.googleapis.com/auth/photoslibrary.readonly",
-            ),
-            scope_groups.get(
-                "photoslibrary_full", "https://www.googleapis.com/auth/photoslibrary"
-            ),
             scope_groups.get(
                 "photoslibrary_append",
                 "https://www.googleapis.com/auth/photoslibrary.appendonly",
@@ -87,12 +82,9 @@ async def _get_photos_service_with_fallback(user_google_email: str):
         logger.debug(f"Using Photos scopes from compatibility shim: {photos_scopes}")
     except Exception as e:
         logger.warning(f"Failed to get photos scopes from compatibility shim: {e}")
-        # Fallback to hardcoded scopes - include app-created data scopes
+        # Fallback to hardcoded scopes - app-created data scopes only
         photos_scopes = [
-            "https://www.googleapis.com/auth/photoslibrary.readonly",
-            "https://www.googleapis.com/auth/photoslibrary",
             "https://www.googleapis.com/auth/photoslibrary.appendonly",
-            # CRITICAL: App-created data scopes required for list/get operations
             "https://www.googleapis.com/auth/photoslibrary.readonly.appcreateddata",
             "https://www.googleapis.com/auth/photoslibrary.edit.appcreateddata",
         ]

--- a/tests/test_photos_scope_separation.py
+++ b/tests/test_photos_scope_separation.py
@@ -1,0 +1,132 @@
+"""
+Test Photos Library scope handling after Google's 2025 API changes.
+
+Google retired the broad photoslibrary/photoslibrary.readonly scopes
+(post March 31, 2025) and rejects authorization requests that combine
+Photos Library scopes with other Google API scopes
+(400 invalid_request: "scopes that cannot be requested together").
+
+These tests are pure registry logic and require no OAuth config or
+external infrastructure, so they run in every environment.
+"""
+
+
+class TestPhotosScopeSeparation:
+    def test_registry_contains_no_retired_photos_scopes(self):
+        """Retired photoslibrary scopes must not exist anywhere in the registry."""
+        from auth.scope_registry import ScopeRegistry
+
+        all_scopes = set()
+        for service_scopes in ScopeRegistry.GOOGLE_API_SCOPES.values():
+            all_scopes.update(service_scopes.values())
+
+        retired_found = all_scopes & ScopeRegistry.RETIRED_SCOPES
+        assert not retired_found, f"Retired scopes still registered: {retired_found}"
+
+    def test_oauth_comprehensive_has_no_photos_scopes(self):
+        """The combined flow must not request Photos scopes alongside Drive."""
+        from auth.scope_registry import ScopeRegistry
+
+        scopes = ScopeRegistry.resolve_scope_group("oauth_comprehensive")
+        photos_scopes = [s for s in scopes if "auth/photoslibrary" in s]
+        assert photos_scopes == [], (
+            f"oauth_comprehensive must not contain Photos scopes "
+            f"(Google rejects the mix with Drive scopes): {photos_scopes}"
+        )
+        # Sanity check that Drive scopes are still present
+        assert any("auth/drive" in s for s in scopes)
+
+    def test_photos_basic_group_uses_valid_scopes_only(self):
+        """photos_basic should resolve to the surviving app-created scopes."""
+        from auth.scope_registry import ScopeRegistry
+
+        scopes = ScopeRegistry.resolve_scope_group("photos_basic")
+        expected = {
+            "https://www.googleapis.com/auth/photoslibrary.appendonly",
+            "https://www.googleapis.com/auth/photoslibrary.readonly.appcreateddata",
+            "https://www.googleapis.com/auth/photoslibrary.edit.appcreateddata",
+        }
+        assert expected <= set(scopes)
+        assert not (set(scopes) & ScopeRegistry.RETIRED_SCOPES)
+
+    def test_get_scopes_for_services_drops_photos_from_mixed_request(self):
+        """Photos must be excluded when combined with other services."""
+        from auth.scope_registry import ScopeRegistry
+
+        scopes = ScopeRegistry.get_scopes_for_services(["drive", "photos"])
+        assert not any("auth/photoslibrary" in s for s in scopes)
+        assert any("auth/drive" in s for s in scopes)
+
+    def test_get_scopes_for_services_honors_photos_only_request(self):
+        """A photos-only selection should still yield Photos scopes."""
+        from auth.scope_registry import ScopeRegistry
+
+        scopes = ScopeRegistry.get_scopes_for_services(["photos"])
+        assert any("auth/photoslibrary" in s for s in scopes)
+        # Base identity scopes are always included and are allowed with Photos
+        assert "https://www.googleapis.com/auth/userinfo.email" in scopes
+
+    def test_validate_scope_combination_rejects_photos_drive_mix(self):
+        """Validation must flag Photos + Drive in one request as invalid."""
+        from auth.scope_registry import ScopeRegistry
+
+        result = ScopeRegistry.validate_scope_combination(
+            [
+                "https://www.googleapis.com/auth/userinfo.email",
+                "openid",
+                "https://www.googleapis.com/auth/photoslibrary.appendonly",
+                "https://www.googleapis.com/auth/drive.file",
+            ]
+        )
+        assert not result.is_valid
+        assert any("cannot be requested together" in w for w in result.warnings)
+
+    def test_validate_scope_combination_allows_photos_only(self):
+        """A photos-only combination (plus base scopes) is valid."""
+        from auth.scope_registry import ScopeRegistry
+
+        result = ScopeRegistry.validate_scope_combination(
+            [
+                "https://www.googleapis.com/auth/userinfo.email",
+                "openid",
+                "https://www.googleapis.com/auth/photoslibrary.appendonly",
+                "https://www.googleapis.com/auth/photoslibrary.readonly.appcreateddata",
+            ]
+        )
+        assert result.is_valid
+
+    def test_settings_drive_scopes_have_no_photos_scopes(self):
+        """settings.drive_scopes (combined bundle) must be Photos-free."""
+        from config.settings import settings
+
+        scopes = settings.drive_scopes
+        photos_scopes = [s for s in scopes if "auth/photoslibrary" in s]
+        assert photos_scopes == []
+
+    def test_settings_fallback_scopes_have_no_photos_scopes(self):
+        """The hardcoded fallback bundle must also be Photos-free."""
+        from config.settings import settings
+
+        photos_scopes = [
+            s for s in settings._fallback_drive_scopes if "auth/photoslibrary" in s
+        ]
+        assert photos_scopes == []
+
+    def test_legacy_photos_mappings_resolve_to_valid_scopes(self):
+        """Compatibility shim photos mappings must use surviving scopes."""
+        from auth.compatibility_shim import CompatibilityShim
+        from auth.scope_registry import ScopeRegistry
+
+        groups = CompatibilityShim.get_legacy_scope_groups()
+        for key in (
+            "photos_read",
+            "photos_append",
+            "photoslibrary_read",
+            "photoslibrary_append",
+            "photoslibrary_readonly_appcreated",
+            "photoslibrary_edit_appcreated",
+        ):
+            assert key in groups, f"Missing legacy mapping: {key}"
+            assert groups[key] not in ScopeRegistry.RETIRED_SCOPES, (
+                f"Legacy mapping {key} resolves to retired scope {groups[key]}"
+            )


### PR DESCRIPTION
Fixes #44

## Problem

Sign-in via the combined OAuth flow fails at Google's consent screen:

> **Access blocked: Authorization Error**
> This request contains scopes that cannot be requested together : [`https://www.googleapis.com/auth/photoslibrary`, `https://www.googleapis.com/auth/drive.file`]
> Error 400: invalid_request

Two Google-side changes cause this:

1. **Mutual exclusion** — Google's auth server now rejects any single authorization request that mixes Photos Library scopes with Drive scopes. Our `oauth_comprehensive` group (used by `initiate_oauth_flow`, the OAuth callback, DCR, and JWT auth) bundled both, so *every* auth attempt 400'd — a hard blocker for all services, not just Photos.
2. **Retired scopes** — `photoslibrary`, `photoslibrary.readonly`, and `photoslibrary.sharing` were removed after March 31, 2025 and return `403 PERMISSION_DENIED`. Only `photoslibrary.appendonly`, `photoslibrary.readonly.appcreateddata`, and `photoslibrary.edit.appcreateddata` remain, and the Library API now only returns app-created content.

## Changes

**`auth/scope_registry.py`**
- Removed the retired `photos.readonly` / `photos.full` scope entries; the registry now carries only the three surviving app-created-data scopes.
- Added `RETIRED_SCOPES` (retired Photos scope URLs) and `SEPARATE_AUTH_SERVICES` (`{"photos"}`) constants.
- Removed `photos.*` from `oauth_comprehensive` so the combined Workspace flow no longer trips the exclusion rule.
- `get_scopes_for_services()` drops Photos (with a logged warning) when it's requested together with other services; a photos-only selection still works (`selected_services=["photos"]`).
- `validate_scope_combination()` now marks any Photos + other-API scope mix as invalid.
- Photos is no longer default-selected in the service catalog, and its description notes the separate sign-in requirement.

**`auth/google_auth.py`** — `initiate_oauth_flow()` validation now flags retired scopes and logs an explicit error when a request mixes Photos scopes with other API scopes.

**`auth/compatibility_shim.py`** — legacy `photos_read` / `photoslibrary_read` mappings now resolve to `readonly.appcreateddata`; photos service defaults use the three surviving scopes.

**`config/settings.py`** — removed Photos scopes from `_fallback_drive_scopes`; the `drive_scopes` problematic-scope check now flags any `photoslibrary` scope in the combined bundle.

**`photos/photos_tools.py`** — fallback service creation requests only the surviving scopes.

**`photos/README.md`** — documents the retired scopes, the app-created-data-only limitation (affects `search_photos`, `list_photos_albums`, `photos_smart_search`, `photos_batch_details`), and the separate-authorization requirement.

**`tests/test_photos_scope_separation.py`** — 10 new tests covering the registry cleanup, the `oauth_comprehensive` exclusion, the mixed-request guard, validation, and the shim mappings. These run without OAuth env vars (unlike `test_oauth_scope_fixes.py`, which is CI-gated).

## Behavior after this change

- The default combined flow (Drive/Gmail/Calendar/etc.) authorizes cleanly again — **this unblocks all sign-ins**.
- Photos must be authorized in its own flow and can only see/manage content this app created. Upload tools (`upload_photos`, `upload_folder_photos`, `create_photos_album`) and reading back app-created content keep working under the new scopes.

## Testing

- `tests/test_photos_scope_separation.py`: 10/10 pass.
- `tests/test_oauth_scope_fixes.py` (with dummy OAuth env): 26 pass, 1 pre-existing unrelated failure (`test_no_datetime_utcnow_in_dynamic_client_registration`, also fails on `main`).
- Full non-client suite: 853 passed / 14 failed — the same 14 fail on unmodified `main` (verified via `git stash`), all unrelated (payment middleware, code mode, e2e tests needing a live server).

## Known limitation / follow-up (tracked in #44)

- Credentials are stored per-email in a single file, so completing a Photos-only auth currently replaces the stored Workspace token for that account. A per-service-group credential dimension is the proper fix and is left as follow-up.
- The Photos Picker API (`photospicker.mediaitems.readonly`) would restore interactive library-wide selection; not integrated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cia7s8itCxRoos4Y6huGcD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cia7s8itCxRoos4Y6huGcD)_