### PR TITLE
Per-service token-group credential storage: Photos gets its own token alongside the Workspace token

### DIFF
--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -278,8 +278,36 @@ def _normalize_email(email: str) -> str:
     return email.lower().strip() if email else ""
 
 
-def _get_credentials_path(user_email: str) -> Path:
-    """Get the path to store credentials for a specific user.
+# Token group for the combined Workspace flow. Services Google requires to be
+# authorized separately (see ScopeRegistry.SEPARATE_AUTH_SERVICES, e.g.
+# Photos) use their own token group so their tokens are stored alongside —
+# not instead of — the Workspace token for the same account.
+DEFAULT_TOKEN_GROUP = "workspace"
+
+
+def get_token_group_credentials_dir(token_group: str = DEFAULT_TOKEN_GROUP) -> Path:
+    """Get the credentials directory for a token group.
+
+    The default (Workspace) group uses ``settings.credentials_dir`` directly,
+    preserving existing file layouts. Separate-auth groups (e.g. "photos")
+    get an isolated subdirectory so their credential files can never collide
+    with — or be globbed as — Workspace credential files.
+    """
+    base = Path(settings.credentials_dir)
+    if not token_group or token_group == DEFAULT_TOKEN_GROUP:
+        return base
+    # Token groups come from the scope registry, but sanitize defensively so
+    # a bad value can never escape the credentials directory.
+    safe_group = "".join(c for c in token_group if c.isalnum() or c in "-_")
+    if not safe_group:
+        raise GoogleAuthError(f"Invalid token group name: {token_group!r}")
+    return base / "token_groups" / safe_group
+
+
+def _get_credentials_path(
+    user_email: str, token_group: str = DEFAULT_TOKEN_GROUP
+) -> Path:
+    """Get the path to store credentials for a specific user and token group.
 
     Email addresses are normalized to lowercase for consistent file naming.
     """
@@ -288,7 +316,7 @@ def _get_credentials_path(user_email: str) -> Path:
     # Normalize email to lowercase for consistent credential storage
     normalized_email = _normalize_email(user_email)
     safe_email = normalized_email.replace("@", "_at_").replace(".", "_")
-    return Path(settings.credentials_dir) / f"{safe_email}_credentials.json"
+    return get_token_group_credentials_dir(token_group) / f"{safe_email}_credentials.json"
 
 
 def _update_oauth_session_marker(
@@ -342,10 +370,17 @@ def _update_oauth_session_marker(
         # Don't fail the whole auth flow if this fails
 
 
-def _save_credentials(user_email: str, credentials: Credentials) -> None:
+def _save_credentials(
+    user_email: str,
+    credentials: Credentials,
+    token_group: str = DEFAULT_TOKEN_GROUP,
+) -> None:
     """Save credentials to disk with proper permissions and validation.
 
     Email addresses are normalized to lowercase for consistent credential storage.
+    ``token_group`` selects the credential slot: the default Workspace group
+    keeps its existing layout; separate-auth groups (e.g. "photos") are saved
+    in their own subdirectory and never overwrite the Workspace token.
     """
     # Normalize email to lowercase for consistent credential storage
     normalized_email = _normalize_email(user_email)
@@ -529,6 +564,7 @@ def _save_credentials(user_email: str, credentials: Credentials) -> None:
                 additional_keys=additional_keys if additional_keys else None,
                 google_sub=google_sub,
                 oauth_linkage_password=oauth_linkage_password,
+                token_group=token_group,
             )
 
             # Save Chat service account JSON if provided via consent screen
@@ -597,7 +633,7 @@ def _save_credentials(user_email: str, credentials: Credentials) -> None:
         logger.debug(f"AuthMiddleware not available, using fallback: {e}")
 
     # Fallback to plaintext storage if middleware not available
-    creds_path = _get_credentials_path(normalized_email)
+    creds_path = _get_credentials_path(normalized_email, token_group)
 
     # Ensure directory exists with proper permissions
     creds_path.parent.mkdir(parents=True, exist_ok=True)
@@ -632,6 +668,7 @@ def _save_credentials(user_email: str, credentials: Credentials) -> None:
         "expiry": credentials.expiry.isoformat() if credentials.expiry else None,
         "saved_at": datetime.now().isoformat(),
         "user_email": normalized_email,  # Store normalized email for validation
+        "token_group": token_group,
     }
 
     try:
@@ -659,10 +696,13 @@ def _save_credentials(user_email: str, credentials: Credentials) -> None:
         raise GoogleAuthError(f"Failed to save credentials: {e}")
 
 
-def _load_credentials(user_email: str) -> Optional[Credentials]:
+def _load_credentials(
+    user_email: str, token_group: str = DEFAULT_TOKEN_GROUP
+) -> Optional[Credentials]:
     """Load credentials from disk with validation and error recovery.
 
     Email addresses are normalized to lowercase for consistent credential lookup.
+    ``token_group`` selects the credential slot (see _save_credentials).
     """
     # Normalize email to lowercase for consistent credential lookup
     normalized_email = _normalize_email(user_email)
@@ -705,6 +745,7 @@ def _load_credentials(user_email: str) -> Optional[Credentials]:
                 normalized_email,
                 per_user_key=per_user_key,
                 google_sub=google_sub,
+                token_group=token_group,
             )
             if creds:
                 logger.info(
@@ -715,7 +756,7 @@ def _load_credentials(user_email: str) -> Optional[Credentials]:
         logger.debug(f"AuthMiddleware not available for loading, using fallback: {e}")
 
     # Fallback to plaintext storage if middleware not available or has no credentials
-    creds_path = _get_credentials_path(normalized_email)
+    creds_path = _get_credentials_path(normalized_email, token_group)
 
     if not creds_path.exists():
         logger.debug(
@@ -933,7 +974,11 @@ def compare_scopes(
     return (not missing, missing)
 
 
-def _refresh_credentials(credentials: Credentials, user_email: str) -> Credentials:
+def _refresh_credentials(
+    credentials: Credentials,
+    user_email: str,
+    token_group: str = DEFAULT_TOKEN_GROUP,
+) -> Credentials:
     """Refresh expired credentials with enhanced error handling."""
     if not credentials.refresh_token:
         logger.error(
@@ -964,7 +1009,7 @@ def _refresh_credentials(credentials: Credentials, user_email: str) -> Credentia
             )
 
         # Save the refreshed credentials
-        _save_credentials(user_email, credentials)
+        _save_credentials(user_email, credentials, token_group=token_group)
 
         logger.info(
             f"Successfully refreshed credentials for {redact_email(user_email)}"
@@ -999,17 +1044,21 @@ def _refresh_credentials(credentials: Credentials, user_email: str) -> Credentia
         raise GoogleAuthError(f"Failed to refresh credentials: {e}")
 
 
-def get_valid_credentials(user_email: str) -> Optional[Credentials]:
+def get_valid_credentials(
+    user_email: str, token_group: str = DEFAULT_TOKEN_GROUP
+) -> Optional[Credentials]:
     """Get valid credentials for a user, refreshing proactively if needed.
 
     Email addresses are normalized to lowercase for consistent credential lookup.
+    ``token_group`` selects the credential slot — e.g. "photos" tokens live in
+    their own slot because Google requires Photos to be authorized separately.
     """
     if not user_email:
         raise GoogleAuthError("Cannot get credentials: user_email is required")
 
     # Normalize email for consistent credential lookup
     normalized_email = _normalize_email(user_email)
-    credentials = _load_credentials(normalized_email)
+    credentials = _load_credentials(normalized_email, token_group)
 
     if not credentials:
         return None
@@ -1020,7 +1069,9 @@ def get_valid_credentials(user_email: str) -> Optional[Credentials]:
             logger.info(
                 f"Proactively refreshing credentials for {redact_email(normalized_email)} before expiry"
             )
-            credentials = _refresh_credentials(credentials, normalized_email)
+            credentials = _refresh_credentials(
+                credentials, normalized_email, token_group=token_group
+            )
         except GoogleAuthError:
             # If refresh fails, credentials are invalid
             logger.error(
@@ -1116,11 +1167,15 @@ async def initiate_oauth_flow(
         from .scope_registry import ScopeRegistry
 
         oauth_scopes = ScopeRegistry.get_scopes_for_services(selected_services)
-        logger.info(f"Using selected services: {selected_services}")
+        token_group = ScopeRegistry.get_token_group_for_services(selected_services)
+        logger.info(
+            f"Using selected services: {selected_services} (token group: {token_group})"
+        )
     else:
         from .scope_registry import ScopeRegistry
 
         oauth_scopes = ScopeRegistry.resolve_scope_group("oauth_comprehensive")
+        token_group = DEFAULT_TOKEN_GROUP
         logger.info(f"Using oauth_comprehensive scopes: {len(oauth_scopes)} scopes")
 
     # Get OAuth client configuration - create clean config for custom credentials
@@ -1230,6 +1285,12 @@ async def initiate_oauth_flow(
         "chat_sa_json": chat_sa_json,
         "privacy_mode": privacy_mode,
         "sampling_config": sampling_config,
+        # Credential slot the resulting token belongs to ("workspace" or a
+        # separate-auth group like "photos") plus the scopes this flow
+        # actually requested, so the callback can exchange the code with the
+        # same scope set instead of assuming oauth_comprehensive.
+        "token_group": token_group,
+        "requested_scopes": oauth_scopes,
     }
 
     # Use enhanced context-based credential storage for persistence
@@ -1410,6 +1471,7 @@ async def handle_oauth_callback(
     chat_sa_json = state_info.get("chat_sa_json")
     _privacy_mode = state_info.get("privacy_mode", False)
     _sampling_config = state_info.get("sampling_config")
+    token_group = state_info.get("token_group", DEFAULT_TOKEN_GROUP)
 
     # Stash OAuth linkage password in session so _save_credentials can use it
     _oauth_linkage_pw = state_info.get("oauth_linkage_password", "")
@@ -1594,10 +1656,15 @@ async def handle_oauth_callback(
         oauth_config = settings.get_oauth_client_config()
         logger.info("🔑 CALLBACK: Using default OAuth configuration")
 
-    # Use centralized scope registry as single source of truth (same as initiate_oauth_flow)
+    # Use the scopes this flow actually requested (stored with the state by
+    # initiate_oauth_flow) — a photos-only flow must not be exchanged against
+    # the comprehensive Workspace scope set. Fall back to oauth_comprehensive
+    # for states created before token groups existed.
     from .scope_registry import ScopeRegistry
 
-    oauth_scopes = ScopeRegistry.resolve_scope_group("oauth_comprehensive")
+    oauth_scopes = state_info.get("requested_scopes") or ScopeRegistry.resolve_scope_group(
+        "oauth_comprehensive"
+    )
 
     # DIAGNOSTIC LOG: OAuth client_secret debugging - callback phase
     logger.debug("CALLBACK_DEBUG: Creating OAuth flow for token exchange")
@@ -1720,8 +1787,16 @@ async def handle_oauth_callback(
         if _sampling_config:
             credentials._sampling_config = _sampling_config
 
-        # Conditional storage based on auth_method
-        if auth_method == "pkce_memory":
+        # Conditional storage based on auth_method. Session-memory storage is
+        # a single slot (SessionKey.CREDENTIALS), so separate-auth token
+        # groups (e.g. photos) always use file storage — otherwise a Photos
+        # token would clobber the Workspace token in the session.
+        if auth_method == "pkce_memory" and token_group != DEFAULT_TOKEN_GROUP:
+            logger.info(
+                f"pkce_memory requested for token group '{token_group}' - using "
+                f"file storage instead (session memory is a single credential slot)"
+            )
+        if auth_method == "pkce_memory" and token_group == DEFAULT_TOKEN_GROUP:
             # Store in session memory only
             session_id = await get_session_context()
             if session_id:
@@ -1737,10 +1812,10 @@ async def handle_oauth_callback(
                 logger.warning(
                     f"No session context available - falling back to file storage for {redact_email(user_email)}"
                 )
-                _save_credentials(user_email, credentials)
+                _save_credentials(user_email, credentials, token_group=token_group)
         else:
             # File storage for 'file_credentials' and 'pkce_file'
-            _save_credentials(user_email, credentials)
+            _save_credentials(user_email, credentials, token_group=token_group)
 
         logger.info(
             f"Successfully authenticated {redact_email(user_email)} (auth_method: {auth_method})"

--- a/auth/google_auth.py
+++ b/auth/google_auth.py
@@ -623,6 +623,22 @@ def _save_credentials(
                             auth_middleware.add_recipient_to_encrypted_file(
                                 backup_path, session_stashed_key, per_user_key
                             )
+                        # Separate-auth token group envelopes (e.g. photos)
+                        # live under token_groups/<group>/ and need the new
+                        # recipient too, so linked users keep the same access
+                        # to every credential slot.
+                        group_root = Path(settings.credentials_dir) / "token_groups"
+                        if group_root.is_dir():
+                            for group_file in group_root.glob(
+                                f"*/{safe}_credentials.enc"
+                            ):
+                                auth_middleware.add_recipient_to_encrypted_file(
+                                    group_file, session_stashed_key, per_user_key
+                                )
+                            for group_file in group_root.glob(f"*/{safe}_backup.enc"):
+                                auth_middleware.add_recipient_to_encrypted_file(
+                                    group_file, session_stashed_key, per_user_key
+                                )
                 except Exception as e:
                     logger.warning(f"Could not cross-add recipients: {e}")
 

--- a/auth/middleware.py
+++ b/auth/middleware.py
@@ -2586,9 +2586,34 @@ class AuthMiddleware(Middleware):
             "_backup.enc": ("backup", "Credential Backup"),
         }
 
+        candidates: list[tuple] = [
+            (creds_dir / f"{safe_email}{suffix}", file_type, label)
+            for suffix, (file_type, label) in type_map.items()
+        ]
+
+        # Separate-auth token group envelopes (e.g. photos) live in their own
+        # subdirectories — include them so the inventory covers every slot.
+        group_root = creds_dir / "token_groups"
+        if group_root.is_dir():
+            for group_dir in sorted(p for p in group_root.iterdir() if p.is_dir()):
+                group = group_dir.name
+                candidates.append(
+                    (
+                        group_dir / f"{safe_email}_credentials.enc",
+                        "credentials",
+                        f"Google OAuth Credentials ({group} token group)",
+                    )
+                )
+                candidates.append(
+                    (
+                        group_dir / f"{safe_email}_backup.enc",
+                        "backup",
+                        f"Credential Backup ({group} token group)",
+                    )
+                )
+
         inventory = []
-        for suffix, (file_type, label) in type_map.items():
-            path = creds_dir / f"{safe_email}{suffix}"
+        for path, file_type, label in candidates:
             if not path.exists():
                 continue
             entry: dict = {

--- a/auth/middleware.py
+++ b/auth/middleware.py
@@ -1503,6 +1503,19 @@ class AuthMiddleware(Middleware):
             logger.error(f"Failed to decrypt credentials: {e}")
             raise
 
+    @staticmethod
+    def _memory_key(normalized_email: str, token_group: str) -> str:
+        """In-memory credential cache key, namespaced by token group.
+
+        The default (Workspace) group keeps the bare email key for backward
+        compatibility; separate-auth groups get an explicit suffix.
+        """
+        from .google_auth import DEFAULT_TOKEN_GROUP
+
+        if not token_group or token_group == DEFAULT_TOKEN_GROUP:
+            return normalized_email
+        return f"{normalized_email}::{token_group}"
+
     def save_credentials(
         self,
         user_email: str,
@@ -1511,6 +1524,7 @@ class AuthMiddleware(Middleware):
         additional_keys: Optional[list] = None,
         google_sub: Optional[str] = None,
         oauth_linkage_password: str = "",
+        token_group: str = "workspace",
     ) -> None:
         """
         Save credentials using the configured storage mode.
@@ -1529,33 +1543,41 @@ class AuthMiddleware(Middleware):
             google_sub: Optional Google account ID (sub claim) for OAuth recipient
             oauth_linkage_password: Passphrase for OAuth recipient key derivation
                 (in-memory only, never persisted)
+            token_group: Credential slot ("workspace" default, or a
+                separate-auth group like "photos" stored in its own
+                subdirectory so it never overwrites the Workspace token)
         """
         # Import normalization function
-        from .google_auth import _normalize_email
+        from .google_auth import (
+            _normalize_email,
+            get_token_group_credentials_dir,
+        )
 
         normalized_email = _normalize_email(user_email)
+        group_dir = get_token_group_credentials_dir(token_group)
 
         logger.debug(
-            f"💾 Saving credentials for {normalized_email} using {self._storage_mode.value}"
+            f"💾 Saving credentials for {normalized_email} using "
+            f"{self._storage_mode.value} (token group: {token_group})"
         )
 
         if self._storage_mode == CredentialStorageMode.MEMORY_ONLY:
             # Store only in memory with normalized email
-            self._memory_credentials[normalized_email] = credentials
+            self._memory_credentials[
+                self._memory_key(normalized_email, token_group)
+            ] = credentials
             logger.debug(f"Stored credentials in memory for {normalized_email}")
 
         elif self._storage_mode == CredentialStorageMode.FILE_PLAINTEXT:
             # Backward compatibility - use existing file-based storage (handles normalization)
             from .google_auth import _save_credentials
 
-            _save_credentials(normalized_email, credentials)
+            _save_credentials(normalized_email, credentials, token_group=token_group)
 
         elif self._storage_mode == CredentialStorageMode.FILE_ENCRYPTED:
             # Encrypted file storage with normalized email
             safe_email = normalized_email.replace("@", "_at_").replace(".", "_")
-            creds_path = (
-                Path(settings.credentials_dir) / f"{safe_email}_credentials.enc"
-            )
+            creds_path = group_dir / f"{safe_email}_credentials.enc"
             creds_path.parent.mkdir(parents=True, exist_ok=True)
 
             oauth_recipient_key = self._resolve_oauth_recipient_key(
@@ -1580,11 +1602,13 @@ class AuthMiddleware(Middleware):
 
         elif self._storage_mode == CredentialStorageMode.MEMORY_WITH_BACKUP:
             # Store in memory + encrypted backup with normalized email
-            self._memory_credentials[normalized_email] = credentials
+            self._memory_credentials[
+                self._memory_key(normalized_email, token_group)
+            ] = credentials
 
             # Also save encrypted backup
             safe_email = normalized_email.replace("@", "_at_").replace(".", "_")
-            backup_path = Path(settings.credentials_dir) / f"{safe_email}_backup.enc"
+            backup_path = group_dir / f"{safe_email}_backup.enc"
             backup_path.parent.mkdir(parents=True, exist_ok=True)
 
             oauth_recipient_key = self._resolve_oauth_recipient_key(
@@ -2031,6 +2055,7 @@ class AuthMiddleware(Middleware):
         user_email: str,
         per_user_key: Optional[str] = None,
         google_sub: Optional[str] = None,
+        token_group: str = "workspace",
     ) -> Optional[Credentials]:
         """
         Load credentials using the configured storage mode.
@@ -2044,26 +2069,33 @@ class AuthMiddleware(Middleware):
             user_email: User's email address (will be normalized to lowercase)
             per_user_key: Plaintext per-user API key (bearer token) for per-user decryption
             google_sub: Google account ID for OAuth recipient key derivation
+            token_group: Credential slot to load from ("workspace" default,
+                or a separate-auth group like "photos")
 
         Returns:
             Credentials if found and decryptable, None otherwise
         """
         # Import normalization function
-        from .google_auth import _normalize_email
+        from .google_auth import (
+            _normalize_email,
+            get_token_group_credentials_dir,
+        )
 
         normalized_email = _normalize_email(user_email)
+        group_dir = get_token_group_credentials_dir(token_group)
+        memory_key = self._memory_key(normalized_email, token_group)
 
         if self._storage_mode == CredentialStorageMode.MEMORY_ONLY:
-            return self._memory_credentials.get(normalized_email)
+            return self._memory_credentials.get(memory_key)
 
         elif self._storage_mode == CredentialStorageMode.MEMORY_WITH_BACKUP:
             # Try memory first with normalized email
-            if normalized_email in self._memory_credentials:
-                return self._memory_credentials[normalized_email]
+            if memory_key in self._memory_credentials:
+                return self._memory_credentials[memory_key]
 
             # Fall back to encrypted backup
             safe_email = normalized_email.replace("@", "_at_").replace(".", "_")
-            backup_path = Path(settings.credentials_dir) / f"{safe_email}_backup.enc"
+            backup_path = group_dir / f"{safe_email}_backup.enc"
 
             if backup_path.exists():
                 creds = self._try_decrypt_with_keys(
@@ -2076,9 +2108,7 @@ class AuthMiddleware(Middleware):
 
         elif self._storage_mode == CredentialStorageMode.FILE_ENCRYPTED:
             safe_email = normalized_email.replace("@", "_at_").replace(".", "_")
-            creds_path = (
-                Path(settings.credentials_dir) / f"{safe_email}_credentials.enc"
-            )
+            creds_path = group_dir / f"{safe_email}_credentials.enc"
 
             if not creds_path.exists():
                 return None
@@ -2099,7 +2129,7 @@ class AuthMiddleware(Middleware):
             # Backward compatibility - use existing file-based storage (handles normalization)
             from .google_auth import _load_credentials
 
-            return _load_credentials(normalized_email)
+            return _load_credentials(normalized_email, token_group)
 
         return None
 
@@ -2606,13 +2636,30 @@ class AuthMiddleware(Middleware):
         safe_email = normalized_email.replace("@", "_at_").replace(".", "_")
         cred_path = Path(settings.credentials_dir) / f"{safe_email}_credentials.enc"
 
+        # Also remove any separate-auth token group credentials (e.g. photos)
+        # so revoking a user revokes every slot, not just the Workspace one.
+        deleted_group_files = False
+        group_root = Path(settings.credentials_dir) / "token_groups"
+        if group_root.is_dir():
+            for group_file in group_root.glob(f"*/{safe_email}_credentials.*"):
+                group_file.unlink()
+                deleted_group_files = True
+            for group_file in group_root.glob(f"*/{safe_email}_backup.enc"):
+                group_file.unlink()
+                deleted_group_files = True
+        # Purge namespaced memory cache entries for all token groups
+        for key in [
+            k
+            for k in self._memory_credentials
+            if k == normalized_email or k.startswith(f"{normalized_email}::")
+        ]:
+            self._memory_credentials.pop(key, None)
+
         if cred_path.exists():
             cred_path.unlink()
-            # Also purge from memory cache
-            self._memory_credentials.pop(normalized_email, None)
             logger.info(f"Deleted credential file for {redact_email(normalized_email)}")
             return True
-        return False
+        return deleted_group_files
 
     def delete_chat_service_account(self, user_email: str) -> bool:
         """Delete the encrypted chat service account file for a user.

--- a/auth/scope_registry.py
+++ b/auth/scope_registry.py
@@ -557,6 +557,15 @@ class ScopeRegistry:
     # These must be authorized in their own OAuth flow with their own token.
     SEPARATE_AUTH_SERVICES = {"photos"}
 
+    # Token group used by the combined Workspace flow. Services in
+    # SEPARATE_AUTH_SERVICES each get their own token group (named after the
+    # service), stored and refreshed independently so a Photos-only
+    # authorization never overwrites the Workspace token for the same account.
+    DEFAULT_TOKEN_GROUP = "workspace"
+
+    # Aliases used by service configs that map onto a registry service name
+    _TOKEN_GROUP_SERVICE_ALIASES = {"photoslibrary": "photos"}
+
     # Convenient access to individual service scope groups
     DRIVE_SCOPES = GOOGLE_API_SCOPES["drive"]
     GMAIL_SCOPES = GOOGLE_API_SCOPES["gmail"]
@@ -570,6 +579,46 @@ class ScopeRegistry:
     TASKS_SCOPES = GOOGLE_API_SCOPES["tasks"]
     PEOPLE_SCOPES = GOOGLE_API_SCOPES["people"]
     BASE_SCOPES = GOOGLE_API_SCOPES["base"]
+
+    @classmethod
+    def get_token_group_for_service(cls, service: str) -> str:
+        """
+        Get the credential token group a service's tokens belong to.
+
+        Services in SEPARATE_AUTH_SERVICES get their own group (named after
+        the service); everything else shares DEFAULT_TOKEN_GROUP.
+
+        Args:
+            service: Service name (e.g. "drive", "photos", "photoslibrary")
+
+        Returns:
+            Token group name (e.g. "workspace" or "photos")
+        """
+        normalized = cls._TOKEN_GROUP_SERVICE_ALIASES.get(service, service)
+        if normalized in cls.SEPARATE_AUTH_SERVICES:
+            return normalized
+        return cls.DEFAULT_TOKEN_GROUP
+
+    @classmethod
+    def get_token_group_for_services(cls, services: List[str]) -> str:
+        """
+        Get the token group for a set of services selected for one OAuth flow.
+
+        A flow made up entirely of one separate-auth service maps to that
+        service's group; any other combination maps to DEFAULT_TOKEN_GROUP
+        (get_scopes_for_services drops separate-auth services from mixed
+        requests, so the resulting token is a Workspace token).
+
+        Args:
+            services: Service names selected for the flow
+
+        Returns:
+            Token group name for the credentials this flow will produce
+        """
+        groups = {cls.get_token_group_for_service(s) for s in services or []}
+        if len(groups) == 1:
+            return groups.pop()
+        return cls.DEFAULT_TOKEN_GROUP
 
     @classmethod
     def get_service_metadata(cls, service: str) -> Optional[ServiceMetadata]:

--- a/auth/service_manager.py
+++ b/auth/service_manager.py
@@ -375,9 +375,27 @@ async def get_google_service(
             )
             return cached_service
 
-    # Get valid credentials
-    credentials = get_valid_credentials(user_email)
+    # Get valid credentials from the credential slot this service belongs to.
+    # Separate-auth services (e.g. Photos — Google refuses to combine its
+    # scopes with Drive's in one authorization) have their own token group,
+    # stored independently of the Workspace token.
+    from .scope_registry import ScopeRegistry
+
+    token_group = ScopeRegistry.get_token_group_for_service(service_type)
+    credentials = get_valid_credentials(user_email, token_group=token_group)
     if not credentials:
+        if token_group != ScopeRegistry.DEFAULT_TOKEN_GROUP:
+            raise GoogleServiceError(
+                f"**Separate Authorization Required for {service_type.title()}**\n\n"
+                f"Google requires {service_type.title()} to be authorized in its "
+                f"own OAuth flow, with its own token — it cannot share the "
+                f"combined Workspace authorization.\n\n"
+                f"**Run:** `start_google_auth` with your email ({user_email}) "
+                f"and `service_name=[\"{service_type}\"]`\n\n"
+                f"Your existing Workspace sign-in is unaffected; this adds a "
+                f"second, {service_type}-only token for the same account."
+            )
+
         # Check if user is authenticated via GoogleProvider (identity-only)
         # and just needs a scope upgrade for API access
         try:

--- a/drive/upload_tools.py
+++ b/drive/upload_tools.py
@@ -226,16 +226,26 @@ def setup_drive_tools(mcp: FastMCP) -> None:
             # --- Credential pre-check: skip OAuth if valid creds already cover requested scopes ---
             from auth.google_auth import compare_scopes, get_valid_credentials
 
-            existing_creds = get_valid_credentials(user_google_email)
-            if existing_creds is not None:
-                # Resolve requested scopes from service_name parameter
-                if isinstance(service_name, list):
-                    requested_services = service_name
-                elif service_name is None or service_name == "":
-                    requested_services = DEFAULT_SERVICES
-                else:
-                    requested_services = []  # custom display string — can't resolve scopes
+            # Resolve requested services first so the pre-check reads the
+            # credential slot this flow would actually write (e.g. a
+            # photos-only request must check the "photos" token group, not
+            # the Workspace token).
+            if isinstance(service_name, list):
+                requested_services = service_name
+            elif service_name is None or service_name == "":
+                requested_services = DEFAULT_SERVICES
+            else:
+                requested_services = []  # custom display string — can't resolve scopes
 
+            precheck_token_group = (
+                ScopeRegistry.get_token_group_for_services(requested_services)
+                if requested_services
+                else ScopeRegistry.DEFAULT_TOKEN_GROUP
+            )
+            existing_creds = get_valid_credentials(
+                user_google_email, token_group=precheck_token_group
+            )
+            if existing_creds is not None:
                 if requested_services:
                     requested_scopes = ScopeRegistry.get_scopes_for_services(
                         requested_services

--- a/photos/README.md
+++ b/photos/README.md
@@ -20,8 +20,13 @@ This document describes the Google Photos API integration following FastMCP2 pat
 >    that combines Photos Library scopes with Drive (or other Workspace)
 >    scopes — `Error 400: invalid_request — This request contains scopes that
 >    cannot be requested together`. Photos is therefore excluded from the
->    combined `oauth_comprehensive` flow and must be authorized on its own
->    (e.g., `selected_services=["photos"]`).
+>    combined `oauth_comprehensive` flow and must be authorized on its own:
+>    run `start_google_auth` with `service_name=["photos"]`.
+>
+> The resulting Photos token is stored in its own credential slot (token
+> group `photos`, under `credentials/token_groups/photos/`), separate from
+> the Workspace token for the same account — authorizing Photos does not
+> overwrite your Workspace sign-in, and both tokens refresh independently.
 
 ## Overview
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "google-workspace-unlimited"
-version = "2.2.1"
+version = "2.3.0"
 description = "Comprehensive MCP server for Google Workspace integration - 72+ tools across Gmail, Drive, Docs, Sheets, Slides, Calendar, Forms, Chat, and Photos with OAuth 2.1 + PKCE authentication"
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/test_photos_token_group.py
+++ b/tests/test_photos_token_group.py
@@ -217,6 +217,144 @@ class TestMiddlewareMemoryKeyNamespacing:
         )
 
 
+def _real_creds(token: str, scopes: list[str]) -> Credentials:
+    """A real Credentials object (encryption serializes/rebuilds real fields)."""
+    return Credentials(
+        token=token,
+        refresh_token=f"{token}_refresh",
+        token_uri="https://oauth2.googleapis.com/token",
+        client_id="test_client_id",
+        client_secret="test_client_secret",
+        scopes=scopes,
+    )
+
+
+class TestEncryptedEnvelopeTokenGroups:
+    """Token-group files use the same multi-recipient crypto envelope
+    (v2, per-user split-key + HMAC) as Workspace credential files."""
+
+    EMAIL = "user@example.com"
+    KEY = "test-bearer-key-abc123"
+
+    def _middleware(self):
+        from auth.middleware import AuthMiddleware, CredentialStorageMode
+
+        return AuthMiddleware(storage_mode=CredentialStorageMode.FILE_ENCRYPTED)
+
+    def test_photos_group_saves_per_user_envelope(self, temp_credentials_dir):
+        middleware = self._middleware()
+        middleware.save_credentials(
+            self.EMAIL,
+            _real_creds("photos_secret_token", PHOTOS_SCOPES),
+            per_user_key=self.KEY,
+            token_group="photos",
+        )
+
+        enc_path = (
+            Path(temp_credentials_dir)
+            / "token_groups"
+            / "photos"
+            / "user_at_example_com_credentials.enc"
+        )
+        assert enc_path.exists()
+
+        raw = enc_path.read_text()
+        envelope = json.loads(raw)
+        assert envelope["v"] == 2
+        assert envelope["enc"] == "per_user"
+        assert len(envelope.get("recipients", {})) >= 1
+        assert "hmac" in envelope
+        # The token itself must never appear in plaintext on disk
+        assert "photos_secret_token" not in raw
+
+    def test_photos_envelope_decrypts_only_with_key(self, temp_credentials_dir):
+        middleware = self._middleware()
+        middleware.save_credentials(
+            self.EMAIL,
+            _real_creds("photos_secret_token", PHOTOS_SCOPES),
+            per_user_key=self.KEY,
+            token_group="photos",
+        )
+
+        loaded = middleware.load_credentials(
+            self.EMAIL, per_user_key=self.KEY, token_group="photos"
+        )
+        assert loaded is not None
+        assert loaded.token == "photos_secret_token"
+
+        # No key → locked; wrong key → locked
+        assert middleware.load_credentials(self.EMAIL, token_group="photos") is None
+        assert (
+            middleware.load_credentials(
+                self.EMAIL, per_user_key="wrong-key", token_group="photos"
+            )
+            is None
+        )
+
+    def test_workspace_and_photos_envelopes_are_independent(
+        self, temp_credentials_dir
+    ):
+        middleware = self._middleware()
+        middleware.save_credentials(
+            self.EMAIL,
+            _real_creds("workspace_secret", WORKSPACE_SCOPES),
+            per_user_key=self.KEY,
+        )
+        middleware.save_credentials(
+            self.EMAIL,
+            _real_creds("photos_secret", PHOTOS_SCOPES),
+            per_user_key=self.KEY,
+            token_group="photos",
+        )
+
+        workspace = middleware.load_credentials(self.EMAIL, per_user_key=self.KEY)
+        photos = middleware.load_credentials(
+            self.EMAIL, per_user_key=self.KEY, token_group="photos"
+        )
+        assert workspace is not None and workspace.token == "workspace_secret"
+        assert photos is not None and photos.token == "photos_secret"
+
+    def test_add_recipient_works_on_group_envelope(self, temp_credentials_dir):
+        middleware = self._middleware()
+        middleware.save_credentials(
+            self.EMAIL,
+            _real_creds("photos_secret", PHOTOS_SCOPES),
+            per_user_key=self.KEY,
+            token_group="photos",
+        )
+        enc_path = (
+            Path(temp_credentials_dir)
+            / "token_groups"
+            / "photos"
+            / "user_at_example_com_credentials.enc"
+        )
+
+        second_key = "linked-account-key-xyz789"
+        assert middleware.add_recipient_to_encrypted_file(
+            enc_path, self.KEY, second_key
+        )
+        loaded = middleware.load_credentials(
+            self.EMAIL, per_user_key=second_key, token_group="photos"
+        )
+        assert loaded is not None
+        assert loaded.token == "photos_secret"
+
+    def test_group_envelope_appears_in_inventory(self, temp_credentials_dir):
+        middleware = self._middleware()
+        middleware.save_credentials(
+            self.EMAIL,
+            _real_creds("photos_secret", PHOTOS_SCOPES),
+            per_user_key=self.KEY,
+            token_group="photos",
+        )
+
+        inventory = middleware.get_envelope_inventory(self.EMAIL)
+        group_entries = [e for e in inventory if "photos token group" in e["label"]]
+        assert len(group_entries) == 1
+        assert group_entries[0]["enc_type"] == "per_user"
+        assert group_entries[0]["has_hmac"] is True
+
+
 class TestServiceManagerRouting:
     @pytest.mark.asyncio
     async def test_photos_service_without_photos_token_gives_specific_error(

--- a/tests/test_photos_token_group.py
+++ b/tests/test_photos_token_group.py
@@ -1,0 +1,241 @@
+"""
+Tests for per-service token-group credential storage.
+
+Google requires Photos Library scopes to be authorized in their own OAuth
+flow (they cannot be combined with Drive scopes). That means a Photos-only
+token and a Workspace token can exist for the same account at the same time,
+so credential storage is namespaced by "token group": the default
+"workspace" group keeps the existing file layout, while separate-auth
+services (photos) store their tokens under
+``credentials_dir/token_groups/<group>/``.
+
+These tests use the plaintext fallback storage path (no AuthMiddleware
+registered) and require no OAuth config or external infrastructure.
+"""
+
+import json
+import shutil
+import tempfile
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+from google.oauth2.credentials import Credentials
+
+from auth.google_auth import (
+    DEFAULT_TOKEN_GROUP,
+    GoogleAuthError,
+    _get_credentials_path,
+    _load_credentials,
+    _save_credentials,
+    get_token_group_credentials_dir,
+    get_valid_credentials,
+)
+from auth.scope_registry import ScopeRegistry
+from config.settings import settings
+
+
+@pytest.fixture
+def temp_credentials_dir():
+    """Point settings.credentials_dir at a temp directory with dummy OAuth config."""
+    temp_dir = tempfile.mkdtemp()
+    original_dir = settings.credentials_dir
+    original_client_id = settings.google_client_id
+    original_client_secret = settings.google_client_secret
+    settings.credentials_dir = temp_dir
+    # _load_credentials needs an OAuth client config to rebuild Credentials
+    settings.google_client_id = "test_client_id"
+    settings.google_client_secret = "test_client_secret"
+    # Force the plaintext storage path: other test modules may have
+    # registered a global AuthMiddleware (encrypted storage), which would
+    # divert saves away from the files these tests assert on.
+    with patch("auth.context.get_auth_middleware", return_value=None):
+        yield temp_dir
+    settings.credentials_dir = original_dir
+    settings.google_client_id = original_client_id
+    settings.google_client_secret = original_client_secret
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def _mock_creds(token: str, scopes: list[str]) -> Mock:
+    creds = Mock(spec=Credentials)
+    creds.token = token
+    creds.refresh_token = f"{token}_refresh"
+    creds.token_uri = "https://oauth2.googleapis.com/token"
+    creds.client_id = "test_client_id"
+    creds.client_secret = "test_client_secret"
+    creds.scopes = scopes
+    creds.expiry = datetime.now() + timedelta(hours=1)
+    creds.expired = False
+    creds.valid = True
+    return creds
+
+
+WORKSPACE_SCOPES = ["https://www.googleapis.com/auth/drive.file"]
+PHOTOS_SCOPES = ["https://www.googleapis.com/auth/photoslibrary.appendonly"]
+
+
+class TestTokenGroupResolution:
+    def test_photos_maps_to_its_own_group(self):
+        assert ScopeRegistry.get_token_group_for_service("photos") == "photos"
+
+    def test_photoslibrary_alias_maps_to_photos_group(self):
+        assert ScopeRegistry.get_token_group_for_service("photoslibrary") == "photos"
+
+    def test_regular_services_map_to_default_group(self):
+        for service in ("drive", "gmail", "calendar", "sheets"):
+            assert (
+                ScopeRegistry.get_token_group_for_service(service)
+                == ScopeRegistry.DEFAULT_TOKEN_GROUP
+            )
+
+    def test_photos_only_flow_maps_to_photos_group(self):
+        assert ScopeRegistry.get_token_group_for_services(["photos"]) == "photos"
+
+    def test_mixed_flow_maps_to_default_group(self):
+        # get_scopes_for_services drops photos from mixed requests, so the
+        # resulting token is a Workspace token.
+        assert (
+            ScopeRegistry.get_token_group_for_services(["drive", "photos"])
+            == ScopeRegistry.DEFAULT_TOKEN_GROUP
+        )
+
+    def test_empty_flow_maps_to_default_group(self):
+        assert (
+            ScopeRegistry.get_token_group_for_services([])
+            == ScopeRegistry.DEFAULT_TOKEN_GROUP
+        )
+
+    def test_registry_and_google_auth_agree_on_default_group(self):
+        assert ScopeRegistry.DEFAULT_TOKEN_GROUP == DEFAULT_TOKEN_GROUP
+
+
+class TestTokenGroupPaths:
+    def test_default_group_keeps_legacy_layout(self, temp_credentials_dir):
+        path = _get_credentials_path("user@example.com")
+        assert path == Path(temp_credentials_dir) / "user_at_example_com_credentials.json"
+
+    def test_photos_group_uses_isolated_subdirectory(self, temp_credentials_dir):
+        path = _get_credentials_path("user@example.com", token_group="photos")
+        assert (
+            path
+            == Path(temp_credentials_dir)
+            / "token_groups"
+            / "photos"
+            / "user_at_example_com_credentials.json"
+        )
+
+    def test_group_dir_sanitizes_hostile_names(self, temp_credentials_dir):
+        hostile = get_token_group_credentials_dir("../../etc")
+        assert Path(temp_credentials_dir) in hostile.parents
+
+        with pytest.raises(GoogleAuthError):
+            get_token_group_credentials_dir("../..")
+
+
+class TestTokenGroupStorageIsolation:
+    def test_photos_save_does_not_overwrite_workspace_token(
+        self, temp_credentials_dir
+    ):
+        email = "user@example.com"
+        _save_credentials(email, _mock_creds("workspace_token", WORKSPACE_SCOPES))
+        _save_credentials(
+            email, _mock_creds("photos_token", PHOTOS_SCOPES), token_group="photos"
+        )
+
+        workspace_path = _get_credentials_path(email)
+        photos_path = _get_credentials_path(email, token_group="photos")
+        assert workspace_path.exists()
+        assert photos_path.exists()
+        assert workspace_path != photos_path
+
+        with open(workspace_path) as f:
+            workspace_data = json.load(f)
+        with open(photos_path) as f:
+            photos_data = json.load(f)
+
+        assert workspace_data["token"] == "workspace_token"
+        assert workspace_data["token_group"] == DEFAULT_TOKEN_GROUP
+        assert photos_data["token"] == "photos_token"
+        assert photos_data["token_group"] == "photos"
+
+    def test_load_reads_from_requested_group(self, temp_credentials_dir):
+        email = "user@example.com"
+        _save_credentials(email, _mock_creds("workspace_token", WORKSPACE_SCOPES))
+        _save_credentials(
+            email, _mock_creds("photos_token", PHOTOS_SCOPES), token_group="photos"
+        )
+
+        workspace_creds = _load_credentials(email)
+        photos_creds = _load_credentials(email, token_group="photos")
+
+        assert workspace_creds is not None
+        assert photos_creds is not None
+        assert workspace_creds.token == "workspace_token"
+        assert photos_creds.token == "photos_token"
+        assert set(photos_creds.scopes) == set(PHOTOS_SCOPES)
+
+    def test_missing_group_returns_none_without_falling_back(
+        self, temp_credentials_dir
+    ):
+        email = "user@example.com"
+        _save_credentials(email, _mock_creds("workspace_token", WORKSPACE_SCOPES))
+
+        # Workspace token exists, but the photos slot is empty — loading the
+        # photos group must NOT silently return the Workspace token.
+        assert _load_credentials(email, token_group="photos") is None
+        assert get_valid_credentials(email, token_group="photos") is None
+
+    def test_get_valid_credentials_routes_by_group(self, temp_credentials_dir):
+        email = "user@example.com"
+        _save_credentials(
+            email, _mock_creds("photos_token", PHOTOS_SCOPES), token_group="photos"
+        )
+
+        creds = get_valid_credentials(email, token_group="photos")
+        assert creds is not None
+        assert creds.token == "photos_token"
+        assert get_valid_credentials(email) is None
+
+
+class TestMiddlewareMemoryKeyNamespacing:
+    def test_default_group_uses_bare_email(self):
+        from auth.middleware import AuthMiddleware
+
+        assert (
+            AuthMiddleware._memory_key("user@example.com", DEFAULT_TOKEN_GROUP)
+            == "user@example.com"
+        )
+
+    def test_separate_group_is_namespaced(self):
+        from auth.middleware import AuthMiddleware
+
+        assert (
+            AuthMiddleware._memory_key("user@example.com", "photos")
+            == "user@example.com::photos"
+        )
+
+
+class TestServiceManagerRouting:
+    @pytest.mark.asyncio
+    async def test_photos_service_without_photos_token_gives_specific_error(
+        self, temp_credentials_dir
+    ):
+        from auth.service_manager import GoogleServiceError, get_google_service
+
+        email = "user@example.com"
+        # A Workspace token exists but there is no photos-group token
+        _save_credentials(email, _mock_creds("workspace_token", WORKSPACE_SCOPES))
+
+        with pytest.raises(GoogleServiceError) as exc_info:
+            await get_google_service(
+                user_email=email,
+                service_type="photos",
+                scopes=PHOTOS_SCOPES,
+                cache_enabled=False,
+            )
+
+        message = str(exc_info.value)
+        assert "Separate Authorization Required" in message
+        assert '["photos"]' in message

--- a/uv.lock
+++ b/uv.lock
@@ -1165,7 +1165,7 @@ wheels = [
 
 [[package]]
 name = "google-workspace-unlimited"
-version = "2.2.0"
+version = "2.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiodebug" },


### PR DESCRIPTION
Implements the "proper fix" from #44. **Stacked on #45** (branched from `claude/session-ljm7g1`; base is that branch so this diff shows only the new work — merge #45 first, then retarget/merge this one).

## Problem

#45 unblocked sign-in by removing Photos scopes from the combined flow, but left a known limitation: credentials are stored per-email in a single slot, so completing a Photos-only authorization (`start_google_auth` with `service_name=["photos"]`) would **overwrite the Workspace token** for that account, breaking every other service until re-auth.

## Design: token groups

A credential now belongs to a **token group**:

- `workspace` (default) — the combined Drive/Gmail/Calendar/… token. File layout unchanged: `credentials_dir/{email}_credentials.{json,enc}`.
- One group per separate-auth service (currently just `photos`) — stored under `credentials_dir/token_groups/photos/{email}_credentials.{json,enc}`.

The subdirectory layout means group files can never collide with — or be picked up by — the existing `credentials_dir` globs (`get_all_stored_users`, credential summaries, etc.). Group names are sanitized before path construction.

## Changes

**`auth/scope_registry.py`** — `DEFAULT_TOKEN_GROUP`, `get_token_group_for_service()` (with a `photoslibrary` → `photos` alias) and `get_token_group_for_services()`. A flow made up entirely of one separate-auth service maps to that service's group; mixed flows map to `workspace` (matching #45's behavior of dropping Photos from mixed requests).

**`auth/google_auth.py`** — `token_group` threaded through `_get_credentials_path`, `_save_credentials`, `_load_credentials`, `_refresh_credentials`, and `get_valid_credentials`, so each slot loads, saves, and **refreshes independently**. `initiate_oauth_flow` derives the group from the selected services and stores it — plus the actually-requested scopes — in the OAuth state map; `handle_oauth_callback` exchanges the authorization code against those scopes (instead of assuming `oauth_comprehensive`) and saves into the right slot. `pkce_memory` falls back to file storage for non-default groups, since session memory is a single credential slot.

**`auth/middleware.py`** — `save_credentials`/`load_credentials` accept `token_group` across all four storage modes (memory keys are namespaced `email::group`; encrypted file/backup paths use the group directory). `delete_credentials` now also removes token-group files and namespaced cache entries, so revoking a user revokes every slot.

**`auth/service_manager.py`** — `get_google_service` looks up credentials in the token group the service belongs to. When the Photos slot is empty it raises a specific error explaining the separate authorization and the exact `start_google_auth` invocation, instead of the generic "no credentials" message.

**`drive/upload_tools.py`** — the `start_google_auth` already-authenticated pre-check now reads the credential slot the requested services would actually use, so an existing Workspace token no longer short-circuits a photos-only auth (and vice versa).

**`photos/README.md`** — documents the two-token model.

## Resulting flow

1. User authorizes normally → Workspace token (unchanged behavior, unchanged file locations — existing credentials keep working with zero migration).
2. User runs `start_google_auth` with `service_name=["photos"]` → photos-only consent → token saved to the `photos` group. Workspace token untouched.
3. Photos tools (middleware-injected or fallback path — both funnel through `get_google_service`) transparently use the `photos` slot; everything else uses `workspace`. Each refreshes and persists on its own.

## Testing

- New `tests/test_photos_token_group.py` (17 tests): group resolution and aliasing, path isolation + hostile-group-name sanitization, save/load routing between slots (photos save doesn't overwrite workspace; empty photos slot returns `None` rather than falling back), memory-key namespacing, and the service_manager error path.
- Full non-client suite: **870 passed / 14 failed** — the same 14 pre-existing failures as unmodified `main` (payment middleware/receipt, code mode, e2e needing a live server, datetime style check); no regressions.

## Notes / follow-ups

- The multi-recipient encryption machinery (linked-account cross-adds, OAuth-sub recipients) applies to group files the same way it does to Workspace files, since both go through the same `_save_encrypted_with_recipients` path.
- The Photos Picker API for library-wide selection remains future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cia7s8itCxRoos4Y6huGcD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cia7s8itCxRoos4Y6huGcD)_