### PR TITLE
Release 2.3.1 — FastMCP 3.4.4 bump and auto Host/Origin guard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ classifiers = [
 ]
 dependencies = [
     # Core MCP Framework
-    "fastmcp[anthropic,tasks,code-mode,apps]>=3.4.0",
+    "fastmcp[anthropic,tasks,code-mode,apps]>=3.4.4",
     "litellm>=1.80.0",
     # Google APIs
     "google-api-python-client>=2.168.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "google-workspace-unlimited"
-version = "2.3.0"
+version = "2.3.1"
 description = "Comprehensive MCP server for Google Workspace integration - 72+ tools across Gmail, Drive, Docs, Sheets, Slides, Calendar, Forms, Chat, and Photos with OAuth 2.1 + PKCE authentication"
 readme = "README.md"
 license = "Apache-2.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 # ============================================
 # Core MCP Framework
 # ============================================
-fastmcp[anthropic,tasks]>=3.0.0b2
+fastmcp[anthropic,tasks,code-mode,apps]>=3.4.4
 
 # ============================================
 # Google APIs

--- a/server.py
+++ b/server.py
@@ -725,6 +725,13 @@ def main():
                     f"🌐 Starting server with {transport_mode.upper()} transport"
                 )
 
+            # Host/Origin request guard (FastMCP 3.4.4+): "auto" blocks DNS
+            # rebinding against localhost-bound servers and leaves public binds
+            # (e.g. FastMCP Cloud) untouched. An explicit
+            # FASTMCP_HTTP_HOST_ORIGIN_PROTECTION env var takes precedence.
+            if os.getenv("FASTMCP_HTTP_HOST_ORIGIN_PROTECTION") is None:
+                run_args["host_origin_protection"] = "auto"
+
             # Run the server with appropriate transport and SSL configuration
             mcp.run(**run_args)
 

--- a/uv.lock
+++ b/uv.lock
@@ -907,14 +907,14 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.4.2"
+version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp-slim", extra = ["client", "server"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/29/18/46beaec18c9f86a599ae3f9cdf6677dd6b50240cfd844d18233710b47f13/fastmcp-3.4.2.tar.gz", hash = "sha256:b468722946fc467c3796a6572f7a14d93d48c014cf8fea12910245220cbbe4e1", size = 28756849, upload-time = "2026-06-06T01:30:35.694Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/f7/5188565d1b93ad611cbd80bf473e7ad669d1f3b689c4bedcd304e1ec3472/fastmcp-3.4.4.tar.gz", hash = "sha256:378202e26ec15b23819d9a1c0d1b0ebda096bc712720532010a0b82a45c2b1df", size = 28796458, upload-time = "2026-07-09T00:32:41.352Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/4d/8b1ba42251160e11ca34686344572121432c23a082d56ef6bbdec5888fc1/fastmcp-3.4.2-py3-none-any.whl", hash = "sha256:c87a62b029f0c5400ada85f683629345d2466c39169f0cb853e487b2f7308c08", size = 8018, upload-time = "2026-06-06T01:30:38.118Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/67/3cef84ba38a23dca1e1e776bfda8a35ab3c7a6c94a8ca81d0715de6dd3c5/fastmcp-3.4.4-py3-none-any.whl", hash = "sha256:f86f208713212260068cf55c32936839eee856fefc7808e18a032f31eb0f718e", size = 8019, upload-time = "2026-07-09T00:32:39.411Z" },
 ]
 
 [package.optional-dependencies]
@@ -933,7 +933,7 @@ tasks = [
 
 [[package]]
 name = "fastmcp-slim"
-version = "3.4.2"
+version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "platformdirs" },
@@ -943,9 +943,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/2e/d627b28b7403ecc526991ef732921b08bde010006e6148635f053fd29f4c/fastmcp_slim-3.4.2.tar.gz", hash = "sha256:290646e0955a516235a317151034559aa48336cb843d3f006131aedad8759bb4", size = 576291, upload-time = "2026-06-06T01:30:12.553Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/79/f35661c6a1d76dfbe17a079f912d96fffcfdd40fad5a9144bb9e7dfb1fdf/fastmcp_slim-3.4.4.tar.gz", hash = "sha256:dcaa3e0be2127d7eacdce592c2ef0039204923dc0ec396454615cb4a3275b078", size = 590203, upload-time = "2026-07-09T00:32:20.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/58/22afebf18df7260b09148199cbeb90cdcc4b3a4e1b5d7460e3591c3a7add/fastmcp_slim-3.4.2-py3-none-any.whl", hash = "sha256:bdc72492212681ca502755fa8acc0457f559295da1fc3dfc0599adc1c04b82f3", size = 749195, upload-time = "2026-06-06T01:30:11.22Z" },
+    { url = "https://files.pythonhosted.org/packages/16/91/321e0b2e9ed70d0628b17ddaec76fc7b09f3e1d5d290f70bf101a2890142/fastmcp_slim-3.4.4-py3-none-any.whl", hash = "sha256:9d3a6327b9ee835188eb7323fc3b5d4cd061631b48da8ece56794bb538972505", size = 765158, upload-time = "2026-07-09T00:32:19.11Z" },
 ]
 
 [package.optional-dependencies]
@@ -1228,7 +1228,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=46.0.5" },
     { name = "fastapi", specifier = ">=0.128.0" },
     { name = "fastembed", specifier = ">=0.7.2" },
-    { name = "fastmcp", extras = ["anthropic", "tasks", "code-mode", "apps"], specifier = ">=3.4.0" },
+    { name = "fastmcp", extras = ["anthropic", "tasks", "code-mode", "apps"], specifier = ">=3.4.4" },
     { name = "google-api-python-client", specifier = ">=2.168.0" },
     { name = "google-auth-httplib2", specifier = ">=0.2.0" },
     { name = "google-auth-oauthlib", specifier = ">=1.2.2" },

--- a/uv.lock
+++ b/uv.lock
@@ -1165,7 +1165,7 @@ wheels = [
 
 [[package]]
 name = "google-workspace-unlimited"
-version = "2.3.0"
+version = "2.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiodebug" },


### PR DESCRIPTION
## Summary

Bumps FastMCP 3.4.2 → 3.4.4, adopts the new opt-in Host/Origin request guard, and cuts release **2.3.1**.

⚠️ Merging this publishes `google-workspace-unlimited` 2.3.1 to PyPI and creates the `v2.3.1` tag + GitHub release (the publish workflow fires on any version change landing on `main`).

The 3.4.3/3.4.4 delta is almost entirely security hardening ([v3.4.3 notes](https://github.com/jlowin/fastmcp/releases/tag/v3.4.3), [v3.4.4 notes](https://github.com/jlowin/fastmcp/releases/tag/v3.4.4)):

- SSRF allow-list bypasses via NAT64/6to4/Teredo/ISATAP IPv6 transition addresses blocked
- OAuth redirect validation rejects unsafe schemes and unregistered DCR redirect URIs
- Streamable HTTP Host/Origin guard against DNS rebinding (opt-in as of 3.4.4)
- Fixes for proxy session teardown races, task tool argument validation, `serialize_by_alias` in tool results

## Changes

- **pyproject.toml**: raise fastmcp floor to `>=3.4.4`; bump project version 2.3.0 → 2.3.1
- **requirements.txt**: align stale pin (was `fastmcp[anthropic,tasks]>=3.0.0b2`, missing the `code-mode`/`apps` extras) with pyproject
- **uv.lock**: fastmcp/fastmcp-slim 3.4.2 → 3.4.4
- **server.py**: opt into `host_origin_protection="auto"` for HTTP transports — protects localhost-bound dev servers from DNS rebinding, no-op for public binds (e.g. FastMCP Cloud). An explicit `FASTMCP_HTTP_HOST_ORIGIN_PROTECTION` env var takes precedence.

## Testing

- `ruff check .`, `ruff format --check .`, and both custom lint scripts pass
- Full pytest suite (CI invocation) run on both `main` @ 3.4.2 and this branch @ 3.4.4: failure sets are **byte-identical** (61 pre-existing environment-dependent failures needing live Qdrant/credentials, 1192 passed) — the bump introduces zero regressions
- Verified `host_origin_protection` kwarg passthrough via `mcp.run()` against the installed 3.4.4 API

🤖 Generated with [Claude Code](https://claude.com/claude-code)