### PR TITLE
Release 2.4.0 — vendor TRM model definitions into adapters/ + add SLOT_PIN_MODE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,9 +59,11 @@ credentials/
 htmlcov/
 
 # Research / ML artifacts
-research/trm/h2/*_training_data.json
-research/trm/h2/checkpoints/*.pt
-research/trm/official-repo/
+# The whole research/ tree is internal-only and excluded from the public repo
+# (removed in 59207e9). Production must NOT import from it -- model definitions
+# live in adapters/ (unified_trn.py, slot_assigner.py, domain_config.py) and are
+# trained by the scripts here.
+research/
 .claude/worktrees/
 
 # Google OAuth credential files (CRITICAL - never commit these)

--- a/adapters/eval_metrics.py
+++ b/adapters/eval_metrics.py
@@ -1,0 +1,167 @@
+"""Search evaluation metrics for TRM pipeline diagnostics.
+
+Provides precision@K, recall@K, MRR, and NDCG for evaluating ranked
+search results. Used by:
+  - Diagnostic UI backend (ml_eval.py endpoints)
+  - E2E pipeline tests
+
+All functions accept lists of ranked results and relevance labels.
+
+Pure stdlib -- no torch, no Qdrant. Lives in `adapters/` (not `research/`) because
+the diagnostic UI ships with the published repo and must not import from the
+internal research tree. `research/trm/h2/eval_metrics.py` re-exports from here.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Dict, List, Optional, Sequence, Union
+
+
+def precision_at_k(
+    ranked_relevant: Sequence[bool],
+    k: int,
+) -> float:
+    """Precision@K: fraction of top-K results that are relevant.
+
+    Args:
+        ranked_relevant: Boolean sequence, True if result at that rank is relevant.
+        k: Number of top results to consider.
+
+    Returns:
+        Precision value in [0.0, 1.0].
+    """
+    if k <= 0:
+        return 0.0
+    top_k = ranked_relevant[:k]
+    if not top_k:
+        return 0.0
+    return sum(1 for r in top_k if r) / k
+
+
+def recall_at_k(
+    ranked_relevant: Sequence[bool],
+    k: int,
+    total_relevant: Optional[int] = None,
+) -> float:
+    """Recall@K: fraction of all relevant items found in top-K.
+
+    Args:
+        ranked_relevant: Boolean sequence, True if result at that rank is relevant.
+        k: Number of top results to consider.
+        total_relevant: Total number of relevant items. If None, counts from
+            the full ranked_relevant sequence.
+
+    Returns:
+        Recall value in [0.0, 1.0].
+    """
+    if total_relevant is None:
+        total_relevant = sum(1 for r in ranked_relevant if r)
+    if total_relevant == 0:
+        return 0.0
+    top_k = ranked_relevant[:k]
+    found = sum(1 for r in top_k if r)
+    return found / total_relevant
+
+
+def mrr(ranked_relevant_lists: Sequence[Sequence[bool]]) -> float:
+    """Mean Reciprocal Rank across multiple queries.
+
+    Args:
+        ranked_relevant_lists: List of ranked_relevant sequences,
+            one per query.
+
+    Returns:
+        MRR value in [0.0, 1.0].
+    """
+    if not ranked_relevant_lists:
+        return 0.0
+    total_rr = 0.0
+    for ranked_relevant in ranked_relevant_lists:
+        for i, is_rel in enumerate(ranked_relevant):
+            if is_rel:
+                total_rr += 1.0 / (i + 1)
+                break
+    return total_rr / len(ranked_relevant_lists)
+
+
+def reciprocal_rank(ranked_relevant: Sequence[bool]) -> float:
+    """Reciprocal rank for a single query.
+
+    Args:
+        ranked_relevant: Boolean sequence for one query.
+
+    Returns:
+        1/rank of first relevant result, or 0.0 if none found.
+    """
+    for i, is_rel in enumerate(ranked_relevant):
+        if is_rel:
+            return 1.0 / (i + 1)
+    return 0.0
+
+
+def dcg_at_k(
+    relevance_scores: Sequence[Union[int, float]],
+    k: int,
+) -> float:
+    """Discounted Cumulative Gain at K.
+
+    Args:
+        relevance_scores: Graded relevance scores in ranked order.
+        k: Number of top results to consider.
+
+    Returns:
+        DCG value (non-negative).
+    """
+    dcg = 0.0
+    for i, rel in enumerate(relevance_scores[:k]):
+        dcg += rel / math.log2(i + 2)  # i+2 because log2(1) = 0
+    return dcg
+
+
+def ndcg_at_k(
+    relevance_scores: Sequence[Union[int, float]],
+    k: int,
+) -> float:
+    """Normalized DCG at K.
+
+    Args:
+        relevance_scores: Graded relevance scores in ranked order.
+        k: Number of top results to consider.
+
+    Returns:
+        NDCG value in [0.0, 1.0].
+    """
+    actual_dcg = dcg_at_k(relevance_scores, k)
+    ideal_scores = sorted(relevance_scores, reverse=True)
+    ideal_dcg = dcg_at_k(ideal_scores, k)
+    if ideal_dcg == 0.0:
+        return 0.0
+    return actual_dcg / ideal_dcg
+
+
+def evaluate_ranked_results(
+    ranked_relevant_lists: Sequence[Sequence[bool]],
+    k_values: Sequence[int] = (1, 3, 5, 10),
+) -> Dict[str, float]:
+    """Compute a full evaluation report across multiple queries.
+
+    Args:
+        ranked_relevant_lists: List of ranked_relevant sequences, one per query.
+        k_values: K values for precision@K and recall@K.
+
+    Returns:
+        Dict with keys like "precision@1", "recall@5", "mrr", etc.
+    """
+    results: Dict[str, float] = {}
+
+    for k in k_values:
+        p_scores = [precision_at_k(rr, k) for rr in ranked_relevant_lists]
+        r_scores = [recall_at_k(rr, k) for rr in ranked_relevant_lists]
+        results[f"precision@{k}"] = sum(p_scores) / len(p_scores) if p_scores else 0.0
+        results[f"recall@{k}"] = sum(r_scores) / len(r_scores) if r_scores else 0.0
+
+    results["mrr"] = mrr(ranked_relevant_lists)
+    results["num_queries"] = float(len(ranked_relevant_lists))
+
+    return results

--- a/adapters/module_wrapper/search_mixin/_learned_model.py
+++ b/adapters/module_wrapper/search_mixin/_learned_model.py
@@ -184,7 +184,7 @@ def _load_learned_model(cls, domain: str | None = None):
 
         if model_type in ("unified", "unified_trn"):
             # UnifiedTRN: dual-encoder with 4 task heads
-            from research.trm.h2.unified_trn import UnifiedTRN
+            from adapters.unified_trn import UnifiedTRN
 
             model = UnifiedTRN(
                 structural_dim=ckpt.get("structural_dim", 17),
@@ -226,6 +226,15 @@ def _load_learned_model(cls, domain: str | None = None):
             f"V{cls._learned_feature_version})"
         )
         return model
+    except ImportError as e:
+        # Checkpoint resolved but the model class is missing -- a packaging bug
+        # (see tests/module/test_no_research_imports.py), not a normal fallback.
+        logger.error(
+            f"Scorer class unavailable ({e}) despite checkpoint at {checkpoint_path} "
+            "— learned search will silently degrade to multidim. The model "
+            "definition must be importable from adapters/unified_trn.py."
+        )
+        return None
     except Exception as e:
         logger.error(f"Failed to load learned scorer: {e}")
         return None

--- a/adapters/slot_assigner.py
+++ b/adapters/slot_assigner.py
@@ -1,0 +1,97 @@
+"""SlotAffinityNet — Tiny neural network for content-to-pool prediction.
+
+Predicts which supply_map pool a content item belongs to.
+Used by the card builder to reassign and reorder supply_map pools before
+sequential consumption, fixing misrouted content items.
+
+Architecture: Linear(384, hidden) → SiLU → Dropout → Linear(hidden, n_pools)
+~25K parameters with hidden=64. Inference: <1ms for 50 pairs.
+
+Pool vocabulary is domain-driven via DomainConfig (default: gchat with 5 pools).
+
+This is the *inference* definition and is the source of truth for production.
+Training scripts live in the internal `research/trm/h2/` tree, which is NOT part
+of the published repo -- production must never import from it. If you change the
+architecture here, mirror it there (and vice versa) or checkpoints stop loading.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+from .domain_config import GCHAT_DOMAIN
+
+# ── Domain-sourced constants (default: gchat) ──────────────────────
+# These module-level constants exist for backward compatibility.
+# New code should use DomainConfig directly.
+_DEFAULT_DOMAIN = GCHAT_DOMAIN
+
+POOL_VOCAB: dict[str, int] = dict(_DEFAULT_DOMAIN.pool_vocab)
+POOL_NAMES: dict[int, str] = _DEFAULT_DOMAIN.pool_names
+N_POOLS = _DEFAULT_DOMAIN.n_pools
+COMPONENT_TO_POOL: dict[str, str] = dict(_DEFAULT_DOMAIN.component_to_pool)
+POOL_SPECIFICITY_ORDER: list[str] = list(_DEFAULT_DOMAIN.specificity_order)
+
+# Legacy compatibility aliases
+SLOT_TYPE_VOCAB = POOL_VOCAB
+SLOT_TO_POOL = {k: k for k in POOL_VOCAB}
+SLOT_TYPE_NAMES = POOL_NAMES
+SPECIFICITY_ORDER = POOL_SPECIFICITY_ORDER
+N_SLOT_TYPES = N_POOLS
+
+
+class SlotAffinityNet(nn.Module):
+    """Direct content-to-pool classifier.
+
+    Input: content embedding (384D MiniLM) → pool class logits.
+    Simpler than pairwise scoring — directly predicts which pool.
+
+    Architecture: Linear(384, hidden) → SiLU → Dropout → Linear(hidden, 5)
+    ~25K parameters with hidden=64.
+    """
+
+    def __init__(
+        self,
+        content_dim: int = 384,
+        slot_embed_dim: int = 16,  # kept for checkpoint compat, unused
+        n_slot_types: int = N_POOLS,
+        hidden: int = 64,
+    ):
+        super().__init__()
+        self.content_dim = content_dim
+        self.slot_embed_dim = slot_embed_dim
+        self.n_slot_types = n_slot_types
+        self.hidden = hidden
+
+        self.classifier = nn.Sequential(
+            nn.Linear(content_dim, hidden),
+            nn.SiLU(),
+            nn.Dropout(0.2),
+            nn.Linear(hidden, n_slot_types),
+        )
+
+    def forward(
+        self, content_emb: torch.Tensor, slot_type_ids: torch.Tensor = None
+    ) -> torch.Tensor:
+        """Classify content items into pools.
+
+        Args:
+            content_emb: [B, content_dim] — MiniLM embeddings of content text
+            slot_type_ids: ignored (kept for API compat)
+
+        Returns:
+            [B, n_pools] class logits
+        """
+        return self.classifier(content_emb)
+
+    def score_all_slots(self, content_emb: torch.Tensor) -> torch.Tensor:
+        """Score a batch of content items against ALL pools.
+
+        Args:
+            content_emb: [B, content_dim]
+
+        Returns:
+            [B, n_pools] class logits
+        """
+        return self.classifier(content_emb)

--- a/adapters/unified_trn.py
+++ b/adapters/unified_trn.py
@@ -1,0 +1,193 @@
+"""UnifiedTRN — Tiny Recursive Network replacing DualHeadScorerMW + SlotAffinityNet.
+
+Single model with shared backbone, 4 task heads:
+  - form_head: component ranking (search mode)
+  - content_head: content ranking (search mode)
+  - pool_head: content-to-pool classification (build mode)
+  - halt_head: learned convergence detector (search mode)
+
+Two operating modes:
+  - search: structural=17D per candidate, content=384D query. Uses form/content/halt heads.
+  - build: structural=zeros(17), content=384D per item. Uses pool_head only.
+
+Architecture:
+  structural_enc: Linear(17,32) → SiLU
+  content_enc: Linear(384,32) → SiLU
+  backbone: [64] → Linear(64,64) → SiLU → Dropout → Linear(64,64) → SiLU → Dropout
+  form_head: Linear(64,32) → SiLU → Linear(32,1)
+  content_head: Linear(64,32) → SiLU → Linear(32,1)
+  pool_head: Linear(64,32) → SiLU → Linear(32,5)
+  halt_head: Linear(64,16) → SiLU → Linear(16,1) → Sigmoid
+
+~28.7K parameters total.
+
+This is the *inference* definition and is the source of truth for production.
+Training scripts live in the internal `research/trm/h2/` tree, which is NOT part
+of the published repo -- production must never import from it. If you change the
+architecture here, mirror it there (and vice versa) or checkpoints stop loading.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+from .domain_config import get_domain_or_default
+
+# V5 feature names (17D) — domain-agnostic structural + content features
+FEATURE_NAMES_V5 = [
+    "sim_c_mean",
+    "sim_c_max",
+    "sim_c_std",
+    "sim_c_coverage",
+    "sim_i_mean",
+    "sim_i_max",
+    "sim_i_std",
+    "sim_i_coverage",
+    "sim_relationships",
+    "is_parent",
+    "is_child",
+    "is_sibling",
+    "depth_ratio",
+    "n_shared_ancestors",
+    "sim_content",
+    "content_density",
+    "content_form_alignment",
+]
+
+STRUCTURAL_DIM = len(FEATURE_NAMES_V5)  # 17
+CONTENT_DIM = 384  # MiniLM
+DEFAULT_N_POOLS = 5  # Override via constructor or DomainConfig
+
+
+def get_domain_defaults(domain_id: str = "gchat") -> dict:
+    """Get pool vocab and component-to-pool mapping for a domain.
+
+    Returns dict with keys: pool_vocab, component_to_pool, n_pools.
+    Falls back to gchat defaults if domain not found.
+    """
+    domain = get_domain_or_default(domain_id)
+    return {
+        "pool_vocab": dict(domain.pool_vocab),
+        "component_to_pool": dict(domain.component_to_pool),
+        "n_pools": domain.n_pools,
+    }
+
+
+class UnifiedTRN(nn.Module):
+    """Unified Tiny Recursive Network.
+
+    Replaces DualHeadScorerMW + SlotAffinityNet with a single model.
+    Two operating modes: search (candidate scoring) and build (content routing).
+    """
+
+    def __init__(
+        self,
+        structural_dim: int = STRUCTURAL_DIM,
+        content_dim: int = CONTENT_DIM,
+        hidden: int = 64,
+        n_pools: int = DEFAULT_N_POOLS,
+        dropout: float = 0.15,
+    ):
+        super().__init__()
+        self.structural_dim = structural_dim
+        self.content_dim = content_dim
+        self.hidden = hidden
+        self.n_pools = n_pools
+
+        enc_dim = 32
+
+        # Separate input encoders (different scales/semantics)
+        self.structural_enc = nn.Sequential(
+            nn.Linear(structural_dim, enc_dim),
+            nn.SiLU(),
+        )
+        self.content_enc = nn.Sequential(
+            nn.Linear(content_dim, enc_dim),
+            nn.SiLU(),
+        )
+
+        # Shared backbone
+        self.backbone = nn.Sequential(
+            nn.Linear(enc_dim * 2, hidden),
+            nn.SiLU(),
+            nn.Dropout(dropout),
+            nn.Linear(hidden, hidden),
+            nn.SiLU(),
+            nn.Dropout(dropout),
+        )
+
+        head_dim = hidden // 2  # 32 when hidden=64
+
+        # Search-mode heads
+        self.form_head = nn.Sequential(
+            nn.Linear(hidden, head_dim),
+            nn.SiLU(),
+            nn.Linear(head_dim, 1),
+        )
+        self.content_head = nn.Sequential(
+            nn.Linear(hidden, head_dim),
+            nn.SiLU(),
+            nn.Linear(head_dim, 1),
+        )
+
+        # Build-mode head
+        self.pool_head = nn.Sequential(
+            nn.Linear(hidden, head_dim),
+            nn.SiLU(),
+            nn.Linear(head_dim, n_pools),
+        )
+
+        # Halt head (learned convergence)
+        # LayerNorm(16) before final projection stabilizes train/eval
+        # scale shift caused by Dropout in the backbone.
+        # NOTE: LayerNorm(1) would kill gradients (single-element norm → always 0).
+        self.halt_head = nn.Sequential(
+            nn.Linear(hidden, 16),
+            nn.LayerNorm(16),
+            nn.SiLU(),
+            nn.Linear(16, 1),
+            nn.Sigmoid(),
+        )
+
+    def forward(
+        self,
+        structural_features: torch.Tensor,
+        content_embedding: torch.Tensor,
+        mode: str = "search",
+    ) -> dict[str, torch.Tensor]:
+        """Forward pass.
+
+        Args:
+            structural_features: [B, structural_dim] — hand-crafted features
+            content_embedding: [B, content_dim] — MiniLM embedding
+            mode: "search", "build", or "all"
+
+        Returns:
+            dict with keys depending on mode:
+              search: form_score [B,1], content_score [B,1], halt_prob [B,1]
+              build: pool_logits [B, n_pools]
+              all: all of the above
+        """
+        s_enc = self.structural_enc(structural_features)  # [B, 32]
+        c_enc = self.content_enc(content_embedding)  # [B, 32]
+
+        combined = torch.cat([s_enc, c_enc], dim=-1)  # [B, 64]
+        shared = self.backbone(combined)  # [B, hidden]
+
+        if mode == "build":
+            return {"pool_logits": self.pool_head(shared)}
+
+        result = {
+            "form_score": self.form_head(shared),
+            "content_score": self.content_head(shared),
+            "halt_prob": self.halt_head(shared),
+        }
+
+        if mode == "all":
+            result["pool_logits"] = self.pool_head(shared)
+
+        return result
+
+    def count_parameters(self) -> int:
+        return sum(p.numel() for p in self.parameters() if p.requires_grad)

--- a/config/settings.py
+++ b/config/settings.py
@@ -356,6 +356,25 @@ class Settings(BaseSettings):
         json_schema_extra={"env": "SEARCH_MODE"},
     )
 
+    # Card-builder slot assignment: how much say the learned model gets over
+    # where content lands. "always" pins an item whenever its current pool has
+    # unmet DSL demand (legacy — the model is then never consulted).
+    # "confidence" lets UnifiedTRN release an item when it prefers a different,
+    # still-demanded pool. See gchat/card_builder/slot_assignment.py.
+    slot_pin_mode: str = Field(
+        default="always",
+        description="Slot assignment pinning: 'always' (legacy) or 'confidence' (model may reroute)",
+        json_schema_extra={"env": "SLOT_PIN_MODE"},
+    )
+
+    # NOTE: pool_head is not calibrated (label_smoothing=0.1 caps max-prob near
+    # 0.92), so this behaves as an on/off switch rather than a tuning dial.
+    slot_reroute_confidence: float = Field(
+        default=0.70,
+        description="Min model confidence to move an item out of its current pool",
+        json_schema_extra={"env": "SLOT_REROUTE_CONFIDENCE"},
+    )
+
     # Shadow A/B scoring — runs all 3 search modes on every query, logs comparison
     search_shadow_scoring: bool = Field(
         default=False,

--- a/docs/TRM_TRANSFER_HANDOFF_2026-07-25.md
+++ b/docs/TRM_TRANSFER_HANDOFF_2026-07-25.md
@@ -1,0 +1,406 @@
+# TRM Cross-Module Transfer — Handoff
+
+**Date:** 2026-07-25 (root cause revised 2026-07-25, later session)
+**Branch:** `chore/bump-fastmcp-3.4.4`
+**Status:** generator bug found and fixed; regenerated + retrained. In-domain and feature-space
+both improved substantially, but **cross-module transfer still fails** for a second, distinct
+reason — see [1b](#1b-why-transfer-still-fails--different-cause-further-down)
+**Predecessor:** [NEXT_STEPS_2026-04-05.md](NEXT_STEPS_2026-04-05.md)
+
+---
+
+## TL;DR
+
+Zero-shot transfer of the gchat-trained `UnifiedTRN` to a second wrapped module
+(`qdrant_client.models`) **fails catastrophically** — it is worse than no model at all.
+**9 of 17 input features are out of distribution**, and all 9 are the ColBERT-derived ones.
+
+> **Correction (superseding the original diagnosis below).** The cause is *not* unrealistic
+> training queries. It is a **shape bug in the training-data generator**: query ColBERT
+> embeddings were kept as a 3-D `[1, tokens, dim]` batch and never unwrapped, so
+> `maxsim_decomposed` normalized and reduced along the token axis instead of the embedding
+> axis. Every ColBERT feature was inflated by ~`sqrt(dim/tokens)` and the max was taken over
+> *document* tokens rather than *query* tokens. Training and inference were computing
+> different statistics. See [The real root cause](#the-real-root-cause).
+
+That has been fixed, regenerated and retrained. It closed most of the feature gap (OOD 9/17 →
+4/17, worst z −12.5 → −3.4) and lifted in-domain `val_form_top1` to 100%, but **transfer is
+still 0.0% Top-1** — because the model keys on *absolute* feature magnitudes whose training
+spread is tiny (sd 0.05–0.13), so a −3σ shift saturates every logit and the reranking becomes
+noise. Next lever is **per-query feature normalization**, not global standardization.
+
+---
+
+## Where things stand (context for a fresh session)
+
+Work completed this session, all verified, **nothing committed**:
+
+| area | state |
+|---|---|
+| `research/` restore | 60 `.py` files + 7 checkpoints recovered from `59207e9^`; `research/` now fully gitignored |
+| Model vendoring | `unified_trn.py`, `slot_assigner.py`, `eval_metrics.py` moved to `adapters/`; `research/` copies are re-export shims |
+| Production imports | zero `research.*` imports in shipped code; guarded by `tests/module/test_no_research_imports.py` (AST scan) |
+| Deleted tests | 1,959 lines restored across 5 files, imports rewired |
+| Slot pin policy | `SLOT_PIN_MODE` added (`always` default / `confidence`), wired into `config/settings.py` |
+| Test suite | 502 passed, 32 skipped; `ruff check` + `ruff format --check` both clean |
+
+Two prior findings that matter here:
+
+- **`pool_head` is uncalibrated.** `label_smoothing=0.1` over 5 pools caps max-prob near
+  0.92; observed range 0.896–0.959. `SLOT_REROUTE_CONFIDENCE` is an on/off switch, not a dial.
+- **Checkpoints have no `data_version`.** The train/val split can't be reproduced, so no
+  existing metric is trustworthy as held-out. This is still NEXT_STEPS #1 and #2.
+
+---
+
+## The finding
+
+### Benchmark
+
+```bash
+python -m research.trm.h2.transfer_eval          # 45 queries, ~1 min
+python -m research.trm.h2.transfer_eval --features-only
+```
+
+Self-labelling: query = each class's docstring with the class name scrubbed out, ground
+truth = that class. `rrf` and `multidim` run identical queries through identical
+retrieval, so any delta is purely the learned model's contribution.
+
+**Result (45 queries, `best_model_unified.pt`, domain=gchat, 28,776 params):**
+
+| mode | Top-1 | MRR | recall@10 |
+|---|---|---|---|
+| rrf | 26.7% | 0.276 | 33.3% |
+| multidim | 20.0% | 0.247 | 33.3% |
+| **learned** | **0.0%** | **0.002** | **2.2%** |
+
+recall@10 collapsing from 33.3% → 2.2% means the model actively pushes correct answers
+*out* of the top 10. Verified not to be an error path: the model loads, the DAG builds
+(298 nodes, max_depth=5), 20 candidates are scored, no exception. Scores cluster in a
+narrow −13 to −14 band — the signature of out-of-distribution input.
+
+### The real root cause
+
+The stored training features are not cosine similarities at all. Over
+`mw_synthetic_groups_v5_hard2.json` (17,825 candidates):
+
+| feature | min | mean | max |
+|---|---|---|---|
+| `sim_c_mean` | 0.436 | 0.951 | 1.708 |
+| `sim_c_max` | 0.662 | 1.858 | **3.103** |
+| `sim_i_max` | 0.164 | 2.188 | **4.372** |
+| `sim_relationships` | −0.136 | 0.238 | 0.815 |
+| `sim_content` | −0.124 | 0.123 | 1.000 |
+
+A MaxSim over unit-norm ColBERT vectors is bounded by 1.0. The dense features
+(`sim_relationships`, `sim_content`) respect that bound; every ColBERT feature does not.
+The stored vectors in Qdrant *are* unit-norm, so the bound cannot be broken by the data.
+
+The mechanism, in `generate_training_data.py`:
+
+```python
+comp_vecs = service.embed_multivector_sync([embed_text])  # -> [1, tokens, dim]
+comp_np   = np.array(comp_vecs, dtype=np.float32)         # 3-D, never unwrapped
+if comp_np.ndim == 1:                                     # only guards the 1-D case
+    comp_np = comp_np.reshape(1, -1)
+```
+
+`embed_multivector_sync` takes a *list* of texts and returns one token matrix per text, so a
+single string yields `[1, tokens, dim]`. Inside `maxsim_decomposed`, `axis=1` is then the
+**token** axis rather than the embedding axis:
+
+- `q_norm` normalizes across tokens per dimension, so rows have norm ≈ `sqrt(dim/tokens)`
+  instead of 1 — with `dim=128`, `tokens=33` that is **1.97×**, and for the shorter DSL
+  `inputs` text (`tokens≈8`) it approaches **4×**. That is exactly the observed ceiling of
+  3.10 for `sim_c_max` and 4.37 for `sim_i_max`.
+- `per_token_max = sim_matrix.max(axis=1)` reduces over *query* tokens, yielding one value
+  per *document* token — a different statistic from the one inference computes.
+- `sim_c_coverage` then counts inflated values against a fixed `0.4` threshold, which is why
+  it saturates at 0.97.
+
+**Verification.** Running the *exact* gchat training query text through the production
+inference path gives `sim_c_coverage = 0.116`, not the 0.967 stored in the training data.
+Query phrasing barely moves the feature at all:
+
+| query | `sim_c_coverage` (inference path) |
+|---|---|
+| eval docstring | 0.213 |
+| training-style component list | 0.230 |
+| **gchat training query, verbatim** | **0.116** |
+| short natural language | 0.341 |
+
+Reproducing the 3-D path against the same corpus lifts coverage from 0.118 → 0.765 and
+`sim_c_max` by 1.93× — matching the predicted `sqrt(128/33) = 1.97`. The gap is the bug,
+not the queries.
+
+### Original (superseded) hypothesis
+
+```
+feature              train mean     sd     live      z
+sim_c_coverage           0.972   0.056    0.213   -13.5   <== OOD
+sim_i_coverage           0.863   0.118    0.116    -6.3   <== OOD
+sim_c_max                1.941   0.310    0.600    -4.3   <== OOD
+sim_c_mean               0.974   0.181    0.282    -3.8   <== OOD
+...                                                        9/17 OOD
+is_parent                0.507   0.500    0.000    -1.0        ok
+is_child                 0.672   0.469    0.000    -1.4        ok
+n_shared_ancestors       0.486   0.268    0.000    -1.8        ok
+```
+
+The **retrieval** features are wrecked; the **DAG** features are fine. That inverts the
+obvious hypothesis (that structural context differs between modules) and points squarely
+at the training-data generator.
+
+The original reading was that `sim_c_coverage ≈ 0.97` meant query tokens were almost fully
+covered because queries were built from the components themselves. **That was wrong** — the
+queries are natural-language descriptions, and running them through the inference path gives
+coverage ≈ 0.12. The saturation came from the axis bug above, not from query construction.
+
+The guess that `sim_c_max` was "a raw MaxSim *sum* that scales with query token count" was
+directionally right about scale but wrong about mechanism: it is a mis-normalized dot
+product, inflated by `sqrt(dim/tokens)`. Note the ColBERT embedder pads to a fixed token
+count for short inputs, so query *length* is not itself the driver.
+
+### Implication beyond transfer
+
+The gchat model is probably weaker on *real* queries than its numbers suggest.
+`val_pool_acc = 94.5%` came from the same synthetic generator, so it inherits the same
+unrealistic regime. Consistent with the historical DualHead result (3.1% when evaluated
+on a difficulty it wasn't trained for).
+
+**The module-wrapper thesis is not refuted — it has never actually been tested**, because
+the training distribution could not reach the test distribution.
+
+---
+
+## Work to do
+
+### 0. Generator shape fix — **DONE**
+
+`research/trm/h2/generate_training_data.py` now has `as_token_matrix()`, which unwraps the
+`[1, tokens, dim]` batch dimension and rejects anything that is not a 2-D token matrix. It is
+applied at all four query-embedding sites and defensively at the top of `maxsim_score` and
+`maxsim_decomposed`, so no call site can reintroduce the axis bug.
+
+Verified: with the fix, the generator and the production inference path
+(`adapters/module_wrapper/search_mixin/_scoring.py::_maxsim_decomposed`) agree on all four
+statistics to float32 precision (max abs diff ≈ 2e-7), and every feature is cosine-bounded.
+
+`research/` is gitignored, so this change is not committed — it lives only in the working tree.
+
+### 1. Regenerate and retrain — **DONE, and transfer still fails**
+
+Ran the full pipeline on the corrected generator:
+
+```bash
+PYTHONPATH=.:research/trm .venv/bin/python -m h2.generate_training_data \
+    --count 500 --variations 3 --seed 42 --domain gchat --feature-version 5 \
+    --output research/trm/h2/mw_synthetic_groups_v5_fixed.json      # 642 groups, 16,050 cands
+PYTHONPATH=.:research/trm .venv/bin/python -m h2.generate_unified_training_data \
+    --search-data research/trm/h2/mw_synthetic_groups_v5_fixed.json \
+    --build-data research/trm/h2/mw_slot_training_data.json \
+    --output research/trm/h2/mw_unified_training_data_fixed.json
+PYTHONPATH=.:research/trm .venv/bin/python -m h2.train_unified \
+    --search-data research/trm/h2/mw_unified_training_data_fixed.json \
+    --domain gchat --checkpoint-dir research/trm/h2/checkpoints_fixed
+LEARNED_SCORER_CHECKPOINT=research/trm/h2/checkpoints_fixed/best_model_unified.pt \
+    PYTHONPATH=. .venv/bin/python -m research.trm.h2.transfer_eval
+```
+
+**In-domain got much better. Transfer did not move.**
+
+| | before fix | after fix |
+|---|---|---|
+| val_form_top1 | 66.1% | **100.0%** |
+| val_pool_acc | 94.5% | 97.3% |
+| features OOD (\|z\|>2) | 9/17 | **4/17** |
+| worst z (`sim_c_coverage`) | −12.5 | **−3.4** |
+| transfer Top-1 | 0.0% | 0.0% |
+| transfer recall@10 | 2.2% | 6.7% |
+
+Two caveats on the in-domain numbers. `val_form_top1 = 100%` is almost certainly optimistic —
+the split is random over groups and only 340 of 642 groups have a unique DSL pattern, so
+near-duplicates straddle it (this is still NEXT_STEPS #1/#2). And the new data has a **12.0%
+form-positive rate vs 60.0% in `v5_hard2`**, because `--max-positives` defaults to 3 and the
+original flags were never recorded — so 100% and 66.1% are not directly comparable.
+
+The feature-space fix is real and large, but it was not sufficient.
+
+### 1b. Why transfer still fails — different cause, further down
+
+Scoring 30 candidates per query on `qdrant_client.models` with the retrained model:
+
+- `form_score` spans **−17.3 to −15.8**, within-query std **0.40**. Every candidate is deep in
+  the negative saturation region — the model calls the entire candidate set a negative.
+- Mean rank of ground truth: **rrf 13.5 vs learned 13.2** (of 30). The learned reranking is not
+  anti-correlated — it is **uninformative**. It replaces rrf's ordering with noise, which is why
+  Top-1 goes to 0: rrf puts ground truth at rank 1 in 3 of 6 resolvable queries
+  (`[1, 28, 23, 1, 1, 27]`), and learned scatters it (`[10, 5, 21, 14, 28, 1]`).
+- Retrieval itself is a ceiling: ground truth appears in the candidate set in only **6 of 12**
+  queries at limit=30, which bounds every mode including the baselines.
+
+The remaining 4 OOD features are `sim_c_mean` (−3.2), `sim_c_max` (−3.7), `sim_c_coverage`
+(−3.4), `sim_i_mean` (−2.1). Note their training **standard deviations are tiny** — 0.059,
+0.051, 0.135, 0.119. The synthetic generator produces a very homogeneous corpus, so a modest
+absolute shift is still several sigma, and the model keys on **absolute feature magnitudes**
+that do not survive a change of module.
+
+**Recommended next step: per-query feature normalization.** Z-score each of the 17 features
+*within a candidate group* (the ~20–30 candidates for one query), in both the generator and
+`_compute_learned_features`. The model then sees "this candidate's coverage is high *relative to
+its competitors*", which is scale-free and domain-independent — exactly what the module-wrapper
+thesis requires. This subsumes the checkpoint-stat standardization in step 2, which only
+rescales globally and would not have prevented the saturation seen here.
+
+### 1c. Original plan (superseded by 1 and 1b)
+
+Every existing `mw_synthetic_groups_v5*.json` and `mw_unified_training_data.json` carries the
+corrupted features, so **all of them must be regenerated** — and every metric derived from
+them (including `val_form_top1 = 66.1%` and `val_pool_acc = 94.5%`) is measured in the wrong
+feature space and is not comparable to post-fix numbers.
+
+1. `generate_training_data.py --domain gchat --feature-version 5` against `mcp_gchat_cards_v8`
+2. `generate_unified_training_data.py` to rebuild `mw_unified_training_data.json`
+3. `train_unified.py`
+4. `python -m research.trm.h2.transfer_eval`
+
+The exact flags that produced `mw_synthetic_groups_v5_hard2.json` (713 groups) were never
+recorded; defaults are `--count 500 --variations 3 --seed 42` with hard negatives on.
+
+### 2. Feature standardization (robustness, not the fix)
+
+The model feeds raw features straight into `Linear(17, 32)` with no normalization.
+
+- **Compute** per-feature mean/std over the training set in
+  `research/trm/h2/train_unified.py`, and **save them into the checkpoint** alongside
+  `structural_dim` / `content_dim`.
+- **Apply** at inference in `adapters/unified_trn.py` — either a non-trainable
+  `nn.BatchNorm1d`-style buffer or an explicit `(x - mean) / std` in `forward()`.
+  Buffers are preferable: they serialize with `state_dict` and can't drift out of sync.
+- **Backward compatibility matters.** Existing checkpoints have no stats. Fall back to
+  identity normalization when absent, so `best_model_unified.pt` keeps loading —
+  `tests/module/test_no_research_imports.py` asserts it does.
+- Consider normalizing `sim_c_max` / `sim_i_max` by query token count at the point of
+  computation (`_compute_learned_features`) so the feature is scale-free by construction.
+  If you change that function, the fix must land in **both** the training generator and
+  the inference path or features silently diverge.
+
+### 3. Realistic query generation (still worth doing, but demoted)
+
+This was the headline fix in the original diagnosis and is no longer believed to be the
+cause of the transfer failure — the synthetic queries are already natural language and land
+in the same coverage regime as real ones. It remains a reasonable diversity improvement once
+the regenerated baseline is in hand, but **do not do it before step 1**, or the two changes
+will be confounded. Options:
+
+- Paraphrase / underspecify ("something to show a couple of actions" → ButtonList)
+- Use real logged queries — `mcp_tool_responses` has genuine `send_dynamic_card` and
+  `qdrant_search` calls
+- Deliberately drop query terms to force lower coverage
+
+Validate by re-running `--features-only` against the *new* training data: the `z` column
+should collapse toward 0. That is the acceptance criterion for step 1 as well.
+
+### 4. Re-run and compare
+
+`python -m research.trm.h2.transfer_eval`. Success = `learned` beats `rrf` (26.7% Top-1)
+on a module it was never trained on. Partial success = `learned` ≥ `rrf`, which would
+still prove the features carry across modules.
+
+### 5. Only then — the round-trip test
+
+Once transfer is non-catastrophic, `qdrant_client.models` supports a far stronger
+evaluation than cards can:
+
+```
+real DSL query → parse_and_build() → Filter object        [ground truth]
+                                          ↓ decompose
+                    (structure DSL, flat bag of keys/values)
+                                          ↓ model reassigns content→slots
+                                     rebuilt Filter
+                                          ↓ execute both against a collection
+                        compare returned point IDs → semantic equivalence
+```
+
+Qdrant filters are **executable**, so correctness is verifiable rather than structural.
+Infrastructure already exists: `middleware/qdrant_core/dsl_query_builder.py`
+(`parse_and_build`), the wrapper (10,019 points in `mcp_qdrant_client_models`), and the
+DSL parser. Only object→(structure, content) decomposition needs writing.
+
+This also yields the **frozen eval set** from NEXT_STEPS #2 for free, since cases are
+generated from real objects rather than sampled from the synthetic pool.
+
+---
+
+## Why `qdrant_client.models` is the right second domain
+
+Measured, not assumed:
+
+| | card_framework.v2 | qdrant_client.models |
+|---|---|---|
+| classes | 113 | 392 |
+| median pairwise similarity | 0.183 | 0.156 |
+| pairs > 0.95 | 0.0% | 0.0% |
+| classes that are containers | 66% | **100%** |
+| mean children per container | 8.7 | **24.4** (max 32) |
+| self-recursive types | — | **26**, incl. `Filter.should` → Filter |
+
+Pre-flight passes: the similarity spread matches the known-learnable gchat baseline, so
+this is *not* the Mancala failure mode (`RETRO.md`: embeddings at 0.99+ are unlearnable).
+An early hypothesis that `Match*`/`Condition` classes would be semantically confusable
+was **wrong** — the `relationships` vector encodes field structure, not just prose, so
+they separate cleanly.
+
+The real difficulty is **compositional**: ~3× branching factor and genuine self-recursion.
+Cards are shallow (`Section → widgets → leaf`); filters are recursive trees. Since the
+recursion in `search_hybrid_recursive` refines the *candidate set* rather than a latent,
+this is the first domain where the target structure is itself recursive — which makes
+accuracy-vs-tree-depth a measurable curve rather than a single number.
+
+---
+
+## Gotchas that cost time this session
+
+- **`embed_multivector_sync` is batch-shaped.** It takes a list of texts and returns a list
+  of token matrices, so embedding one string gives `[1, tokens, dim]`. A `ndim == 1` guard
+  does not catch it, and NumPy will happily broadcast the 3-D array through a matmul and
+  produce plausible-looking numbers. Sanity-check that ColBERT features stay within `[-1, 1]`
+  — that single check would have caught this immediately.
+- **Two implementations of the same feature will drift.** `maxsim_decomposed` (training) and
+  `_maxsim_decomposed` (inference) were textually near-identical and still disagreed, because
+  the bug was in the *caller's* array shape. Compare the two numerically on shared inputs, not
+  by reading them side by side.
+- **HTTP 200 is not verification.** Google Chat accepts and stores a card, returns 200,
+  then the client silently declines to render it. Read the echoed response body.
+- **A button without `onClick` kills the entire card** client-side. `validate_structure`
+  catches this (message: *"card will be silently dropped"*) and `fix_structure` repairs it,
+  but only via `validate_and_repair_card`, which is called from `gchat/card_tools.py`.
+  **Calling `build_from_params` directly bypasses the repair layer** — that is a test
+  harness bug, not a builder bug.
+- **`.env` does not reach `os.environ`.** pydantic-settings populates `Settings` only.
+  Read config through `config.settings`, not `os.environ`, or `.env` is silently ignored.
+- **`SEARCH_MODE=recursive` is set in `.env`** — the learned path is live in this
+  configuration, so scorer regressions affect real behaviour.
+- The pin-policy `except Exception` in `_should_release` and the loader `except ImportError`
+  paths are deliberate: they fail toward safe behaviour, but they will hide real errors.
+  Check logs at ERROR level before assuming a path is healthy.
+
+---
+
+## Key files
+
+| purpose | path |
+|---|---|
+| Transfer benchmark | `research/trm/h2/transfer_eval.py` |
+| Model definition (inference) | `adapters/unified_trn.py` |
+| Feature computation | `adapters/module_wrapper/search_mixin/_learned_model.py` |
+| Recursive search loop | `adapters/module_wrapper/search_mixin/_hybrid_recursive.py` |
+| Training (unified) | `research/trm/h2/train_unified.py` |
+| Training data generator | `research/trm/h2/generate_unified_training_data.py` |
+| Qdrant wrapper | `middleware/qdrant_core/qdrant_models_wrapper.py` |
+| DSL → object builder | `middleware/qdrant_core/dsl_query_builder.py` |
+| Slot assignment + pin policy | `gchat/card_builder/slot_assignment.py` |
+| Import guard test | `tests/module/test_no_research_imports.py` |
+
+**Reminder:** `research/` is gitignored and excluded from the published repo. Production
+must never import from it — the guard test fails the build if it does.

--- a/gchat/card_builder/slot_assignment.py
+++ b/gchat/card_builder/slot_assignment.py
@@ -243,6 +243,106 @@ def _embed_texts(texts: List[str], wrapper: Any) -> Optional[Any]:
         return None
 
 
+def _pin_policy() -> Tuple[str, float]:
+    """Resolve the pinning policy from the environment.
+
+    "always" (default, legacy): an item stays in its current pool whenever that
+        pool still has unmet demand -- the model is never consulted for items
+        that happen to land somewhere with room. Misrouted content stays
+        misrouted whenever supply counts line up with DSL demand.
+
+    "confidence": consult the model first. An item is released for rerouting
+        only when the model confidently prefers a *different, still-demanded*
+        pool. Releasing an item hands its slot back to remaining_demand, so the
+        number of unassigned items and the unmet demand stay balanced and no
+        pool can be starved by the reroute.
+
+    Calibration caveat (measured 2026-07-25 on mw_slot_training_data.json):
+        pool_head probabilities are saturated, not calibrated. train_unified.py
+        uses label_smoothing=0.1 over 5 pools, capping the true-class target at
+        ~0.92, and observed max-probs span only 0.896-0.959 (median 0.928).
+        Top-1-vs-current margin does not separate either: correct-but-moved
+        items scored 0.900-0.905, inside the 0.835-0.910 range of genuine fixes.
+        So SLOT_REROUTE_CONFIDENCE is effectively an on/off switch, not a dial —
+        anything below ~0.89 releases on every disagreement, anything above
+        ~0.96 releases nothing. It is kept as an escape hatch, not a tuning knob.
+        Making it a real dial needs a calibrated pool_head (temperature scaling,
+        or dropping label smoothing) evaluated on a frozen eval set.
+
+    Configuration (both resolve the same two knobs):
+        .env / Settings   slot_pin_mode, slot_reroute_confidence
+        process env       SLOT_PIN_MODE, SLOT_REROUTE_CONFIDENCE  (takes priority)
+
+    Note pydantic-settings reads .env into Settings but does *not* populate
+    os.environ, so .env alone is invisible to a bare os.environ lookup -- hence
+    the Settings fallback below. Values are "always" / 0.70 if neither is set.
+    """
+    default_mode, default_threshold = "always", 0.70
+    try:
+        from config.settings import settings
+
+        default_mode = getattr(settings, "slot_pin_mode", default_mode)
+        default_threshold = getattr(
+            settings, "slot_reroute_confidence", default_threshold
+        )
+    except Exception as e:  # settings unavailable (e.g. isolated unit tests)
+        logger.debug(f"Settings unavailable for pin policy, using defaults: {e}")
+
+    mode = os.environ.get("SLOT_PIN_MODE", str(default_mode)).strip().lower()
+    if mode not in ("always", "confidence"):
+        logger.warning(f"Unknown SLOT_PIN_MODE={mode!r} — falling back to 'always'")
+        mode = "always"
+
+    raw = os.environ.get("SLOT_REROUTE_CONFIDENCE", str(default_threshold))
+    try:
+        threshold = float(raw)
+    except ValueError:
+        logger.warning(f"Invalid SLOT_REROUTE_CONFIDENCE={raw!r} — using 0.70")
+        threshold = 0.70
+    threshold = min(max(threshold, 0.0), 1.0)
+
+    return mode, threshold
+
+
+def _should_release(
+    scores: Any,
+    source_pool: str,
+    remaining_demand: Dict[str, int],
+    vocab: Dict[str, int],
+    threshold: float,
+) -> bool:
+    """True when the model confidently wants this item in a different pool.
+
+    Deliberately conservative — every guard here fails toward pinning:
+      * no score for the item  -> pin
+      * model agrees with the current pool -> pin
+      * the preferred pool has no unmet demand -> pin (nowhere to move it)
+      * confidence below threshold -> pin
+    """
+    if scores is None:
+        return False
+
+    try:
+        import torch
+
+        probs = torch.softmax(scores, dim=-1)
+        best_id = int(probs.argmax())
+        confidence = float(probs[best_id])
+    except Exception as e:  # never let the policy break card building
+        logger.debug(f"Release check failed, pinning instead: {e}")
+        return False
+
+    id_to_pool = {v: k for k, v in vocab.items()}
+    preferred = id_to_pool.get(best_id)
+
+    if preferred is None or preferred == source_pool:
+        return False
+    if remaining_demand.get(preferred, 0) <= 0:
+        return False
+
+    return confidence >= threshold
+
+
 def _get_constants(domain_config: Any = None):
     """Get pool vocab, component-to-pool, and specificity order from DomainConfig."""
     domain = domain_config if domain_config is not None else _get_domain_config()
@@ -349,16 +449,35 @@ def reassign_supply_map(
     new_pools: Dict[str, List[Any]] = {k: [] for k in VOCAB}
     remaining_demand: Dict[str, int] = dict(pool_demands)
 
+    pin_mode, reroute_confidence = _pin_policy()
+    released = 0
+
     for i, (item, source_pool) in enumerate(all_items):
         demand_for_pool = remaining_demand.get(source_pool, 0)
-        if demand_for_pool > 0:
-            # This item's pool is demanded and not yet full — pin it
-            new_pools[source_pool].append(item)
-            assigned[i] = True
-            remaining_demand[source_pool] = demand_for_pool - 1
+        if demand_for_pool <= 0:
+            continue
+
+        # Under "confidence" mode the model gets a say *before* the pin:
+        # an item is released for rerouting only when the model confidently
+        # prefers a different pool that is itself demanded.
+        if pin_mode == "confidence" and _should_release(
+            item_scores[i], source_pool, remaining_demand, VOCAB, reroute_confidence
+        ):
+            released += 1
+            continue
+
+        # This item's pool is demanded and not yet full — pin it
+        new_pools[source_pool].append(item)
+        assigned[i] = True
+        remaining_demand[source_pool] = demand_for_pool - 1
 
     pinned = sum(assigned)
     unpinned = len(all_items) - pinned
+    if released:
+        logger.info(
+            f"🧠 Slot assignment: {released} item(s) released for rerouting by the "
+            f"model (pin_mode=confidence, threshold={reroute_confidence:.2f})"
+        )
     if unpinned > 0:
         logger.debug(f"🧠 Slot assignment: {pinned} pinned, {unpinned} to reroute")
 

--- a/gchat/card_builder/slot_assignment.py
+++ b/gchat/card_builder/slot_assignment.py
@@ -121,7 +121,7 @@ def _load_slot_model():
 
     if unified_path and Path(unified_path).exists():
         try:
-            from research.trm.h2.unified_trn import UnifiedTRN
+            from adapters.unified_trn import UnifiedTRN
 
             checkpoint = torch.load(unified_path, map_location="cpu", weights_only=True)
             model = UnifiedTRN(
@@ -154,6 +154,17 @@ def _load_slot_model():
                 f"pool={pool_acc:.1%}, content={content_acc:.1%})"
             )
             return model
+        except ImportError as e:
+            # The model class is missing, not the checkpoint. That is a packaging
+            # bug (see tests/module/test_no_research_imports.py), not a normal
+            # degradation path -- surface it loudly instead of quietly falling
+            # back to heuristic content routing.
+            logger.error(
+                f"UnifiedTRN class unavailable ({e}) despite checkpoint at "
+                f"{unified_path} — slot assignment will fall back to heuristics. "
+                "This is a packaging bug: the model definition must be importable "
+                "from adapters/unified_trn.py."
+            )
         except Exception as e:
             logger.warning(f"Failed to load UnifiedTRN: {e} — trying SlotAffinityNet")
 
@@ -169,7 +180,7 @@ def _load_slot_model():
         return None
 
     try:
-        from research.trm.h2.slot_assigner import SlotAffinityNet
+        from adapters.slot_assigner import SlotAffinityNet
 
         checkpoint = torch.load(slot_path, map_location="cpu", weights_only=True)
         model = SlotAffinityNet(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "google-workspace-unlimited"
-version = "2.3.1"
+version = "2.4.0"
 description = "Comprehensive MCP server for Google Workspace integration - 72+ tools across Gmail, Drive, Docs, Sheets, Slides, Calendar, Forms, Chat, and Photos with OAuth 2.1 + PKCE authentication"
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/module/test_cross_domain_builder.py
+++ b/tests/module/test_cross_domain_builder.py
@@ -1,0 +1,274 @@
+"""Cross-domain builder E2E tests.
+
+Tests that the same description can produce valid output in both gchat and email
+domains, with correct pool routing, supply maps, and output format validation.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from adapters.domain_config import EMAIL_DOMAIN, GCHAT_DOMAIN
+from adapters.module_wrapper.builder_base import (
+    BuilderProtocol,
+    ComponentRegistry,
+    ParsedStructure,
+)
+
+# ── Fixtures ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def gchat_builder():
+    from gchat.card_builder.builder_v3 import GchatCardBuilder
+
+    return GchatCardBuilder()
+
+
+@pytest.fixture
+def email_builder():
+    from gmail.email_builder import EmailBuilder
+
+    return EmailBuilder()
+
+
+# ── Protocol compliance ───────────────────────────────────────────────
+
+
+class TestProtocolCompliance:
+    """Both builders satisfy BuilderProtocol."""
+
+    def test_gchat_is_builder(self, gchat_builder):
+        assert isinstance(gchat_builder, BuilderProtocol)
+
+    def test_email_is_builder(self, email_builder):
+        assert isinstance(email_builder, BuilderProtocol)
+
+    def test_both_have_different_domains(self, gchat_builder, email_builder):
+        assert gchat_builder.domain_id == "gchat"
+        assert email_builder.domain_id == "email"
+
+
+# ── Pool routing correctness ─────────────────────────────────────────
+
+
+class TestPoolRoutingPerDomain:
+    """Supply maps use correct pool keys per domain."""
+
+    def test_gchat_pools(self, gchat_builder):
+        parsed = ParsedStructure(content_items={}, raw_dsl="")
+        sm = gchat_builder.build_supply_map(parsed)
+        assert set(sm.keys()) == set(GCHAT_DOMAIN.pool_vocab.keys())
+
+    def test_email_pools(self, email_builder):
+        parsed = ParsedStructure(content_items={}, raw_dsl="")
+        sm = email_builder.build_supply_map(parsed)
+        assert set(sm.keys()) == set(EMAIL_DOMAIN.pool_vocab.keys())
+
+    def test_gchat_content_routes_to_content_texts(self, gchat_builder):
+        parsed = ParsedStructure(
+            content_items={"content_texts": ["Hello", "World"]},
+        )
+        sm = gchat_builder.build_supply_map(parsed)
+        assert sm["content_texts"] == ["Hello", "World"]
+
+    def test_email_content_routes_to_content(self, email_builder):
+        parsed = ParsedStructure(
+            content_items={"content": ["Hello", "World"]},
+        )
+        sm = email_builder.build_supply_map(parsed)
+        assert sm["content"] == ["Hello", "World"]
+
+    def test_gchat_buttons_route_to_buttons_pool(self, gchat_builder):
+        parsed = ParsedStructure(
+            content_items={"buttons": ["Click me"]},
+        )
+        sm = gchat_builder.build_supply_map(parsed)
+        assert sm["buttons"] == ["Click me"]
+
+    def test_email_interactive_routes_to_interactive_pool(self, email_builder):
+        parsed = ParsedStructure(
+            content_items={"interactive": ["Submit"]},
+        )
+        sm = email_builder.build_supply_map(parsed)
+        assert sm["interactive"] == ["Submit"]
+
+
+# ── Output format validation ─────────────────────────────────────────
+
+
+class TestOutputFormatValidation:
+    """Output type validation: dict for gchat, EmailSpec for email."""
+
+    def test_email_build_returns_email_spec(self, email_builder):
+        from gmail.mjml_types import EmailSpec
+
+        result = email_builder.build(
+            "Welcome newsletter", subject="Welcome!", text="Hello subscriber"
+        )
+        assert isinstance(result, EmailSpec)
+
+    def test_email_spec_to_mjml_valid(self, email_builder):
+        result = email_builder.build("Test", subject="Test", text="Hello")
+        mjml = result.to_mjml()
+        assert isinstance(mjml, str)
+        assert "<mjml>" in mjml
+        assert "<mj-body" in mjml
+        assert "</mjml>" in mjml
+
+    def test_email_build_with_hero(self, email_builder):
+        from gmail.mjml_types import EmailSpec
+
+        result = email_builder.build(
+            "Hero email",
+            subject="Welcome",
+            hero_title="Big Announcement",
+            hero_subtitle="Something exciting",
+            text="Details here",
+        )
+        assert isinstance(result, EmailSpec)
+        assert len(result.blocks) >= 2  # Hero + Text at minimum
+
+    def test_email_build_with_all_block_types(self, email_builder):
+        from gmail.mjml_types import EmailSpec
+
+        result = email_builder.build(
+            "Full email",
+            subject="Everything",
+            header_title="My Company",
+            hero_title="Big News",
+            text="Read on...",
+            image_src="https://example.com/img.png",
+            button_text="Learn More",
+            button_url="https://example.com",
+            divider=True,
+            table_headers=["Name", "Value"],
+            table_rows=[["A", "1"], ["B", "2"]],
+            accordion_items=[
+                {"title": "FAQ 1", "content": "Answer 1"},
+                {"title": "FAQ 2", "content": "Answer 2"},
+            ],
+            social_links=[
+                {"name": "twitter", "href": "https://twitter.com/example"},
+            ],
+            footer_text="(c) 2026 My Company",
+            unsubscribe_url="https://example.com/unsub",
+        )
+        assert isinstance(result, EmailSpec)
+        mjml = result.to_mjml()
+        assert "<mjml>" in mjml
+        # Should have multiple block types rendered
+        assert "mj-text" in mjml
+        assert "mj-button" in mjml
+        assert "mj-image" in mjml
+
+    def test_email_build_with_explicit_blocks(self, email_builder):
+        """Passing explicit blocks bypasses auto-generation."""
+        from gmail.mjml_types import ButtonBlock, EmailSpec, TextBlock
+
+        blocks = [
+            TextBlock(text="Hello"),
+            ButtonBlock(text="Click", url="https://example.com"),
+        ]
+        result = email_builder.build("ignored", subject="Test", blocks=blocks)
+        assert isinstance(result, EmailSpec)
+        assert len(result.blocks) == 2
+
+
+# ── Render component per domain ──────────────────────────────────────
+
+
+class TestRenderComponentPerDomain:
+    """render_component produces domain-correct output."""
+
+    def test_email_render_text(self, email_builder):
+        result = email_builder.render_component("TextBlock", {"text": "Hello"})
+        assert isinstance(result, str)
+        assert "mj-text" in result
+
+    def test_email_render_button(self, email_builder):
+        result = email_builder.render_component(
+            "ButtonBlock", {"text": "Go", "url": "https://example.com"}
+        )
+        assert isinstance(result, str)
+        assert "mj-button" in result
+
+    def test_email_render_image(self, email_builder):
+        result = email_builder.render_component(
+            "ImageBlock", {"src": "https://example.com/img.png"}
+        )
+        assert isinstance(result, str)
+        assert "mj-image" in result
+
+    def test_email_render_hero(self, email_builder):
+        result = email_builder.render_component("HeroBlock", {"title": "Welcome"})
+        assert isinstance(result, str)
+        assert "Welcome" in result
+
+    def test_email_render_spacer(self, email_builder):
+        result = email_builder.render_component("SpacerBlock", {"height_px": 30})
+        assert isinstance(result, str)
+        assert "mj-spacer" in result
+
+    def test_email_render_divider(self, email_builder):
+        result = email_builder.render_component("DividerBlock", {})
+        assert isinstance(result, str)
+        assert "mj-divider" in result
+
+    def test_email_render_footer(self, email_builder):
+        result = email_builder.render_component(
+            "FooterBlock", {"text": "Copyright 2026"}
+        )
+        assert isinstance(result, str)
+        assert "Copyright 2026" in result
+
+    def test_email_render_unknown(self, email_builder):
+        result = email_builder.render_component("FakeBlock", {"x": 1})
+        assert isinstance(result, str)
+        assert "Unknown" in result or "Error" in result
+
+
+# ── Full mocked pipeline for both domains ────────────────────────────
+
+
+class TestMockedPipelineBothDomains:
+    """Full mocked pipeline for both domains."""
+
+    def test_gchat_reassign_uses_gchat_domain(self, gchat_builder):
+        supply_map = {pool: [] for pool in GCHAT_DOMAIN.pool_vocab}
+        supply_map["content_texts"] = ["Hello"]
+
+        with patch("gchat.card_builder.slot_assignment.reassign_supply_map") as mock:
+            mock.return_value = supply_map
+            result = gchat_builder.reassign_slots(supply_map, {"DecoratedText": 1})
+            mock.assert_called_once()
+            _, kwargs = mock.call_args
+            assert kwargs.get("domain_config") is GCHAT_DOMAIN
+
+    def test_email_reassign_uses_email_domain(self, email_builder):
+        supply_map = {pool: [] for pool in EMAIL_DOMAIN.pool_vocab}
+        supply_map["content"] = ["Hello"]
+
+        with patch("gchat.card_builder.slot_assignment.reassign_supply_map") as mock:
+            mock.return_value = supply_map
+            result = email_builder.reassign_slots(supply_map, {"TextBlock": 1})
+            mock.assert_called_once()
+            _, kwargs = mock.call_args
+            assert kwargs.get("domain_config") is EMAIL_DOMAIN
+
+    def test_both_domains_build_without_errors(self, gchat_builder, email_builder):
+        """Both builders can build from the same high-level description."""
+        # Email build (doesn't need wrapper/Qdrant)
+        email_result = email_builder.build(
+            "Status dashboard",
+            subject="Status Update",
+            text="Everything is operational",
+            button_text="View Dashboard",
+            button_url="https://example.com/status",
+        )
+        from gmail.mjml_types import EmailSpec
+
+        assert isinstance(email_result, EmailSpec)
+        assert email_result.subject == "Status Update"
+        mjml = email_result.to_mjml()
+        assert "<mjml>" in mjml

--- a/tests/module/test_domain_generalization.py
+++ b/tests/module/test_domain_generalization.py
@@ -1,0 +1,488 @@
+"""Cross-domain generalization tests for the TRM pipeline.
+
+Tests that the training data generation, model architecture, and domain config
+system work correctly across multiple domains (gchat, email) without Qdrant.
+"""
+
+import importlib.util
+
+import pytest
+import torch
+
+from adapters.domain_config import (
+    EMAIL_DOMAIN,
+    GCHAT_DOMAIN,
+    DomainConfig,
+    get_domain,
+    get_domain_or_default,
+    list_domains,
+    register_domain,
+    resolve_domain,
+)
+from adapters.unified_trn import (
+    CONTENT_DIM,
+    DEFAULT_N_POOLS,
+    FEATURE_NAMES_V5,
+    STRUCTURAL_DIM,
+    UnifiedTRN,
+    get_domain_defaults,
+)
+
+
+def _has_research_tree() -> bool:
+    """The training-data generators live in the internal research/trm tree.
+
+    That tree is excluded from the published repo, so tests exercising it skip
+    cleanly rather than fail. Everything the *production* code needs lives in
+    adapters/ and is covered by the unguarded tests below.
+    """
+    try:
+        return (
+            importlib.util.find_spec("research.trm.h2.generate_training_data")
+            is not None
+        )
+    except (ImportError, ModuleNotFoundError, ValueError):
+        return False
+
+
+requires_research = pytest.mark.skipif(
+    not _has_research_tree(),
+    reason="requires internal research/trm tree (not part of the published repo)",
+)
+
+
+def research_get_domain(domain_id: str):
+    """Resolve a domain from the *research* config.
+
+    content_affinity / content_templates / confusion_pairs are training-only
+    corpora consumed solely by the training-data generators. The production
+    config in adapters/ keeps the dataclass fields (so checkpoint round-trips
+    still work) but ships them empty. Tests asserting on that corpus must
+    therefore read the research config, not the production one.
+    """
+    from research.trm.h2.domain_config import get_domain as _get_domain
+
+    return _get_domain(domain_id)
+
+
+# ── Domain Config Content Knowledge ──────────────────────────────────
+
+
+@requires_research
+class TestDomainContentKnowledge:
+    """Verify content_affinity, content_templates, confusion_pairs for all domains."""
+
+    @pytest.mark.parametrize("domain_id", ["gchat", "email"])
+    def test_domain_has_content_knowledge(self, domain_id):
+        domain = research_get_domain(domain_id)
+        assert domain.has_content_knowledge, f"{domain_id} missing content knowledge"
+
+    @pytest.mark.parametrize("domain_id", ["gchat", "email"])
+    def test_content_affinity_entries_correspond_to_real_components(self, domain_id):
+        """Content affinity keys with non-empty patterns should be pool-mapped components.
+
+        Some components (like SelectionInput, TextInput) may have affinity entries
+        for training data diversity but don't need pool mappings — they're just
+        extra context, not routing targets. We only check non-structural types.
+        """
+        domain = research_get_domain(domain_id)
+        all_components = set(domain.component_to_pool.keys())
+        unmapped = []
+        for comp_name, affinity in domain.content_affinity.items():
+            if comp_name not in all_components and affinity.get("type") not in (
+                "structural",
+                "input",
+                "temporal",
+                "toggle",
+            ):
+                unmapped.append(comp_name)
+        # Allow some unmapped — they're used for content generation, not pool routing
+        assert len(unmapped) <= 5, (
+            f"{domain_id}: too many unmapped affinity keys: {unmapped}"
+        )
+
+    @pytest.mark.parametrize("domain_id", ["gchat", "email"])
+    def test_pool_mapped_components_have_affinity_or_templates(self, domain_id):
+        """Components with pool mappings should ideally have content knowledge."""
+        domain = research_get_domain(domain_id)
+        # Check that at least some pool-mapped components have content
+        mapped_with_content = sum(
+            1
+            for comp in domain.component_to_pool
+            if comp in domain.content_affinity or comp in domain.content_templates
+        )
+        total_mapped = len(domain.component_to_pool)
+        coverage = mapped_with_content / total_mapped if total_mapped > 0 else 0
+        assert coverage > 0.3, (
+            f"{domain_id}: only {coverage:.0%} of components have content knowledge"
+        )
+
+    @pytest.mark.parametrize("domain_id", ["gchat", "email"])
+    def test_content_affinity_entries_have_patterns_and_type(self, domain_id):
+        domain = research_get_domain(domain_id)
+        for comp_name, affinity in domain.content_affinity.items():
+            assert "patterns" in affinity, f"{comp_name} missing 'patterns'"
+            assert "type" in affinity, f"{comp_name} missing 'type'"
+            assert isinstance(affinity["patterns"], list)
+
+    @pytest.mark.parametrize("domain_id", ["gchat", "email"])
+    def test_content_templates_are_nonempty_lists(self, domain_id):
+        domain = research_get_domain(domain_id)
+        for comp_name, templates in domain.content_templates.items():
+            assert isinstance(templates, list)
+            assert len(templates) > 0, f"{comp_name} has empty templates list"
+
+    @pytest.mark.parametrize("domain_id", ["gchat", "email"])
+    def test_confusion_pairs_reference_valid_pools(self, domain_id):
+        domain = research_get_domain(domain_id)
+        valid_pools = set(domain.pool_vocab.keys())
+        for text, wrong_pool in domain.confusion_pairs:
+            assert wrong_pool in valid_pools, (
+                f"{domain_id}: confusion pair pool '{wrong_pool}' not in pool_vocab"
+            )
+
+    def test_checkpoint_round_trip_preserves_content(self):
+        """from_checkpoint should preserve content_affinity, templates, confusion_pairs."""
+        domain = GCHAT_DOMAIN
+        ckpt = {
+            "domain_id": domain.domain_id,
+            "pool_vocab": dict(domain.pool_vocab),
+            "component_to_pool": dict(domain.component_to_pool),
+            "specificity_order": list(domain.specificity_order),
+            "rewrap_rules": dict(domain.rewrap_rules),
+            "content_affinity": dict(domain.content_affinity),
+            "content_templates": dict(domain.content_templates),
+            "confusion_pairs": [list(p) for p in domain.confusion_pairs],
+        }
+        restored = DomainConfig.from_checkpoint(ckpt)
+        assert restored is not None
+        assert restored.domain_id == "gchat"
+        assert len(restored.content_affinity) == len(domain.content_affinity)
+        assert len(restored.content_templates) == len(domain.content_templates)
+        assert len(restored.confusion_pairs) == len(domain.confusion_pairs)
+
+
+# ── Domain Content Switching ─────────────────────────────────────────
+
+
+@requires_research
+class TestDomainContentSwitching:
+    """Test that generate_training_data content loads correctly per domain."""
+
+    def test_gchat_content_loads_by_default(self):
+        from research.trm.h2 import generate_training_data as gtd
+
+        # Module import triggers gchat init
+        assert len(gtd.CONTENT_AFFINITY) > 0
+        assert "ButtonList" in gtd.CONTENT_AFFINITY
+
+    def test_switch_to_email_loads_email_content(self):
+        from research.trm.h2 import generate_training_data as gtd
+
+        gtd._init_domain_content("email")
+        try:
+            assert "HeroBlock" in gtd.CONTENT_AFFINITY
+            assert "TextBlock" in gtd.CONTENT_TEXT_TEMPLATES
+            assert "ButtonList" not in gtd.CONTENT_AFFINITY
+            assert gtd._active_domain_config.domain_id == "email"
+        finally:
+            # Restore gchat default
+            gtd._init_domain_content("gchat")
+
+    def test_switch_back_to_gchat_restores(self):
+        from research.trm.h2 import generate_training_data as gtd
+
+        gtd._init_domain_content("email")
+        gtd._init_domain_content("gchat")
+        assert "ButtonList" in gtd.CONTENT_AFFINITY
+        assert "HeroBlock" not in gtd.CONTENT_AFFINITY
+
+    def test_content_text_generation_uses_active_domain(self):
+        from research.trm.h2 import generate_training_data as gtd
+
+        gtd._init_domain_content("email")
+        try:
+            text = gtd._generate_content_text_for_components(["HeroBlock", "TextBlock"])
+            assert len(text) > 0, "Email content text should not be empty"
+        finally:
+            gtd._init_domain_content("gchat")
+
+    def test_unknown_domain_falls_back_to_gchat(self):
+        """Unknown domain falls back to gchat via get_domain_or_default."""
+        from research.trm.h2 import generate_training_data as gtd
+
+        gtd._init_domain_content("nonexistent_domain")
+        try:
+            # get_domain_or_default returns gchat for unknown domains
+            assert gtd._active_domain_config.domain_id == "gchat"
+            assert len(gtd.CONTENT_AFFINITY) > 0
+        finally:
+            gtd._init_domain_content("gchat")
+
+
+# ── Cross-Domain Model Architecture ─────────────────────────────────
+
+
+class TestCrossDomainModel:
+    """Verify UnifiedTRN works correctly with different domain pool counts."""
+
+    @pytest.mark.parametrize("domain_id", ["gchat", "email"])
+    def test_model_with_domain_pool_count(self, domain_id):
+        domain = get_domain(domain_id)
+        model = UnifiedTRN(n_pools=domain.n_pools)
+        assert model.n_pools == domain.n_pools
+
+        # Search mode
+        out = model(
+            torch.randn(3, STRUCTURAL_DIM),
+            torch.randn(3, CONTENT_DIM),
+            mode="search",
+        )
+        assert out["form_score"].shape == (3, 1)
+        assert out["content_score"].shape == (3, 1)
+
+        # Build mode — pool_logits should match domain's pool count
+        out = model(
+            torch.zeros(3, STRUCTURAL_DIM),
+            torch.randn(3, CONTENT_DIM),
+            mode="build",
+        )
+        assert out["pool_logits"].shape == (3, domain.n_pools)
+
+    def test_gchat_and_email_models_are_distinct(self):
+        """Models for different domains have different pool head dimensions."""
+        gchat_model = UnifiedTRN(n_pools=GCHAT_DOMAIN.n_pools)
+        email_model = UnifiedTRN(n_pools=EMAIL_DOMAIN.n_pools)
+
+        # Both should have same backbone but different pool heads
+        assert gchat_model.structural_dim == email_model.structural_dim
+        assert gchat_model.content_dim == email_model.content_dim
+        # Pool head output differs if n_pools differs
+        gchat_pool_out = gchat_model.pool_head[-1].out_features
+        email_pool_out = email_model.pool_head[-1].out_features
+        assert gchat_pool_out == GCHAT_DOMAIN.n_pools
+        assert email_pool_out == EMAIL_DOMAIN.n_pools
+
+    def test_get_domain_defaults_returns_correct_values(self):
+        gchat = get_domain_defaults("gchat")
+        email = get_domain_defaults("email")
+        assert gchat["n_pools"] == 5
+        assert email["n_pools"] == 5  # Both happen to be 5 now
+        assert "ButtonList" in gchat["component_to_pool"]
+        assert "HeroBlock" in email["component_to_pool"]
+
+    def test_model_handles_zero_structural_features(self):
+        """Build mode uses zeros for structural — must not produce NaN."""
+        for domain_id in ["gchat", "email"]:
+            domain = get_domain(domain_id)
+            model = UnifiedTRN(n_pools=domain.n_pools)
+            model.eval()
+            out = model(
+                torch.zeros(5, STRUCTURAL_DIM),
+                torch.randn(5, CONTENT_DIM),
+                mode="build",
+            )
+            assert not torch.isnan(out["pool_logits"]).any()
+            assert not torch.isinf(out["pool_logits"]).any()
+
+
+# ── Domain Checkpoint Matching ───────────────────────────────────────
+
+
+class TestCheckpointDomainMatching:
+    """Test that checkpoints carry domain metadata and resolve correctly."""
+
+    def _make_checkpoint(self, domain: DomainConfig) -> dict:
+        """Create a minimal checkpoint dict with domain metadata."""
+        model = UnifiedTRN(n_pools=domain.n_pools)
+        return {
+            "model_state_dict": model.state_dict(),
+            "model_type": "unified_trn",
+            "structural_dim": STRUCTURAL_DIM,
+            "content_dim": CONTENT_DIM,
+            "hidden": 64,
+            "n_pools": domain.n_pools,
+            "dropout": 0.15,
+            "feature_version": 5,
+            "domain_id": domain.domain_id,
+            "pool_vocab": dict(domain.pool_vocab),
+            "component_to_pool": dict(domain.component_to_pool),
+            "specificity_order": list(domain.specificity_order),
+            "rewrap_rules": dict(domain.rewrap_rules),
+            "content_affinity": dict(domain.content_affinity),
+            "content_templates": dict(domain.content_templates),
+            "confusion_pairs": [list(p) for p in domain.confusion_pairs],
+        }
+
+    def test_gchat_checkpoint_resolves_to_gchat(self):
+        ckpt = self._make_checkpoint(GCHAT_DOMAIN)
+        resolved = resolve_domain(checkpoint=ckpt)
+        assert resolved.domain_id == "gchat"
+        assert resolved.n_pools == GCHAT_DOMAIN.n_pools
+
+    def test_email_checkpoint_resolves_to_email(self):
+        ckpt = self._make_checkpoint(EMAIL_DOMAIN)
+        resolved = resolve_domain(checkpoint=ckpt)
+        assert resolved.domain_id == "email"
+        assert resolved.n_pools == EMAIL_DOMAIN.n_pools
+        assert "HeroBlock" in resolved.component_to_pool
+
+    def test_checkpoint_domain_overrides_explicit(self):
+        """Checkpoint metadata should take priority over --domain arg."""
+        ckpt = self._make_checkpoint(EMAIL_DOMAIN)
+        resolved = resolve_domain(checkpoint=ckpt, domain_id="gchat")
+        assert resolved.domain_id == "email"
+
+    @requires_research
+    def test_checkpoint_preserves_content_knowledge(self):
+        # Content knowledge is training-only data -- source the fat research
+        # config so there is a corpus to round-trip in the first place.
+        ckpt = self._make_checkpoint(research_get_domain("email"))
+        restored = DomainConfig.from_checkpoint(ckpt)
+        assert restored.has_content_knowledge
+        assert "HeroBlock" in restored.content_affinity
+        assert "TextBlock" in restored.content_templates
+
+    def test_model_loads_with_checkpoint_domain(self):
+        """Model constructed from checkpoint metadata should have correct n_pools."""
+        for domain in [GCHAT_DOMAIN, EMAIL_DOMAIN]:
+            ckpt = self._make_checkpoint(domain)
+            restored = DomainConfig.from_checkpoint(ckpt)
+            model = UnifiedTRN(
+                structural_dim=ckpt["structural_dim"],
+                content_dim=ckpt["content_dim"],
+                hidden=ckpt["hidden"],
+                n_pools=restored.n_pools,
+            )
+            model.load_state_dict(ckpt["model_state_dict"])
+            assert model.n_pools == domain.n_pools
+
+
+# ── Feature Dimension Consistency ────────────────────────────────────
+
+
+class TestFeatureDimensionConsistency:
+    """Verify feature dimensions are consistent across the system."""
+
+    def test_v5_features_have_17_dimensions(self):
+        assert len(FEATURE_NAMES_V5) == 17
+
+    def test_structural_dim_matches_features(self):
+        assert STRUCTURAL_DIM == len(FEATURE_NAMES_V5)
+
+    def test_content_dim_is_384(self):
+        assert CONTENT_DIM == 384
+
+    def test_default_n_pools_is_5(self):
+        assert DEFAULT_N_POOLS == 5
+
+    def test_model_structural_input_matches_features(self):
+        model = UnifiedTRN()
+        # First layer of structural_enc should accept STRUCTURAL_DIM
+        first_layer = model.structural_enc[0]
+        assert first_layer.in_features == STRUCTURAL_DIM
+
+    def test_model_content_input_matches_dim(self):
+        model = UnifiedTRN()
+        first_layer = model.content_enc[0]
+        assert first_layer.in_features == CONTENT_DIM
+
+    @pytest.mark.parametrize("domain_id", ["gchat", "email"])
+    def test_domain_pool_count_matches_model_output(self, domain_id):
+        """Pool head output dimension must match domain's pool count."""
+        domain = get_domain(domain_id)
+        model = UnifiedTRN(n_pools=domain.n_pools)
+        pool_out_dim = model.pool_head[-1].out_features
+        assert pool_out_dim == domain.n_pools
+
+
+# ── Slot Training Data Domain Integration ────────────────────────────
+
+
+@requires_research
+class TestSlotTrainingDomainIntegration:
+    """Test generate_slot_training_data domain-aware initialization."""
+
+    def test_slot_domain_init_gchat(self):
+        from research.trm.h2.generate_slot_training_data import (
+            COMPONENT_TO_POOL,
+            POOL_VOCAB,
+            _init_slot_domain,
+        )
+
+        _init_slot_domain("gchat")
+        assert "buttons" in POOL_VOCAB
+        assert "Button" in COMPONENT_TO_POOL
+
+    def test_slot_domain_init_email(self):
+        from research.trm.h2 import generate_slot_training_data as gstd
+
+        gstd._init_slot_domain("email")
+        try:
+            # Access via module to get updated globals
+            assert "content" in gstd.POOL_VOCAB
+            assert "HeroBlock" in gstd.COMPONENT_TO_POOL
+            assert "Button" not in gstd.COMPONENT_TO_POOL
+        finally:
+            gstd._init_slot_domain("gchat")
+
+
+# ── Email Domain Specifics ───────────────────────────────────────────
+
+
+class TestEmailDomainSpecifics:
+    """Validate EMAIL_DOMAIN matches the real MJML wrapper components."""
+
+    EXPECTED_MJML_COMPONENTS = {
+        "EmailSpec",
+        "HeroBlock",
+        "TextBlock",
+        "ButtonBlock",
+        "ImageBlock",
+        "ColumnsBlock",
+        "Column",
+        "SpacerBlock",
+        "DividerBlock",
+        "HeaderBlock",
+        "FooterBlock",
+        "SocialBlock",
+        "TableBlock",
+        "AccordionBlock",
+        "CarouselBlock",
+    }
+
+    def test_all_mjml_components_mapped(self):
+        """Every known MJML component should be in component_to_pool."""
+        mapped = set(EMAIL_DOMAIN.component_to_pool.keys())
+        missing = self.EXPECTED_MJML_COMPONENTS - mapped
+        assert not missing, f"Missing MJML components: {missing}"
+
+    def test_no_phantom_components(self):
+        """No components in the mapping that don't exist in MJML."""
+        mapped = set(EMAIL_DOMAIN.component_to_pool.keys())
+        extra = mapped - self.EXPECTED_MJML_COMPONENTS
+        assert not extra, f"Phantom components: {extra}"
+
+    def test_pool_categories_match_dsl_categories(self):
+        """Pool structure should mirror DSL categories from email_wrapper_setup.py."""
+        expected_pools = {"content", "layout", "chrome", "structure", "interactive"}
+        actual_pools = set(EMAIL_DOMAIN.pool_vocab.keys())
+        assert actual_pools == expected_pools
+
+    def test_content_pool_has_main_blocks(self):
+        """Core content blocks should be in the 'content' pool."""
+        for comp in ["HeroBlock", "TextBlock", "ButtonBlock", "ImageBlock"]:
+            assert EMAIL_DOMAIN.component_to_pool[comp] == "content"
+
+    def test_layout_pool_has_columns(self):
+        assert EMAIL_DOMAIN.component_to_pool["ColumnsBlock"] == "layout"
+        assert EMAIL_DOMAIN.component_to_pool["Column"] == "layout"
+
+    def test_chrome_pool_has_header_footer(self):
+        assert EMAIL_DOMAIN.component_to_pool["HeaderBlock"] == "chrome"
+        assert EMAIL_DOMAIN.component_to_pool["FooterBlock"] == "chrome"
+        assert EMAIL_DOMAIN.component_to_pool["SocialBlock"] == "chrome"
+
+    def test_interactive_pool_has_accordion_carousel(self):
+        assert EMAIL_DOMAIN.component_to_pool["AccordionBlock"] == "interactive"
+        assert EMAIL_DOMAIN.component_to_pool["CarouselBlock"] == "interactive"

--- a/tests/module/test_no_research_imports.py
+++ b/tests/module/test_no_research_imports.py
@@ -1,0 +1,159 @@
+"""Guard: published code must never import from the internal `research/` tree.
+
+Background — this test exists because of a real outage. Commit 59207e9 removed
+`research/` from the published repo, but production kept importing model classes
+from `research.trm.h2.*`. Both the learned search scorer and the card builder's
+slot assignment caught the resulting ImportError in a broad `except`, logged, and
+silently degraded to heuristics. That went unnoticed for roughly three months.
+
+The fix was to move the inference definitions into `adapters/` (unified_trn,
+slot_assigner, domain_config, eval_metrics) and leave only training scripts in
+`research/`. These tests keep it that way:
+
+  1. No shipped module may reference `research.` at all (static scan).
+  2. The model classes and their checkpoints must load from `adapters/` alone.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Directories that ship in the published repo and therefore must stay clean.
+SHIPPED_DIRS = [
+    "adapters",
+    "gchat",
+    "gmail",
+    "tools",
+    "config",
+    "middleware",
+    "auth",
+    "resources",
+]
+
+# `research/` itself and its own shims are exempt, as are these tests.
+EXEMPT_PARTS = {".venv", "__pycache__", "node_modules", ".claude", "research"}
+
+
+def _shipped_python_files() -> list[Path]:
+    files: list[Path] = []
+    for d in SHIPPED_DIRS:
+        root = REPO_ROOT / d
+        if not root.is_dir():
+            continue
+        for p in root.rglob("*.py"):
+            if EXEMPT_PARTS & set(p.relative_to(REPO_ROOT).parts):
+                continue
+            files.append(p)
+    return files
+
+
+def _research_imports(path: Path) -> list[str]:
+    """Return `research.*` imports in a file, including function-local ones."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except (SyntaxError, UnicodeDecodeError):
+        return []
+
+    offenders: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            # level > 0 is a relative import and can never reach research/
+            if node.level == 0 and (node.module or "").split(".")[0] == "research":
+                offenders.append(f"line {node.lineno}: from {node.module} import ...")
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.split(".")[0] == "research":
+                    offenders.append(f"line {node.lineno}: import {alias.name}")
+    return offenders
+
+
+def test_no_shipped_module_imports_research():
+    """Static scan — catches the exact regression that broke the learned stack."""
+    files = _shipped_python_files()
+    assert files, "found no shipped Python files to scan — check SHIPPED_DIRS"
+
+    violations = {
+        str(p.relative_to(REPO_ROOT)): found
+        for p in files
+        if (found := _research_imports(p))
+    }
+
+    assert not violations, (
+        "Shipped code imports from the internal research/ tree, which is absent "
+        "from the published repo. Move the definition into adapters/ instead.\n"
+        + "\n".join(
+            f"  {path}\n    " + "\n    ".join(hits)
+            for path, hits in sorted(violations.items())
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "module_path,symbol",
+    [
+        ("adapters.unified_trn", "UnifiedTRN"),
+        ("adapters.slot_assigner", "SlotAffinityNet"),
+        ("adapters.domain_config", "resolve_domain"),
+        ("adapters.eval_metrics", "reciprocal_rank"),
+    ],
+)
+def test_inference_definitions_live_in_adapters(module_path, symbol):
+    """The symbols production needs must be importable without research/."""
+    module = importlib.import_module(module_path)
+    assert hasattr(module, symbol), f"{module_path} is missing {symbol}"
+
+
+def test_learned_scorer_loads_when_checkpoint_present():
+    """A resolvable checkpoint must actually produce a model, not a silent None.
+
+    This is the assertion that fails loudly if the model class goes missing
+    again: checkpoint resolution succeeding while loading returns None is
+    precisely the signature of the outage described above.
+    """
+    pytest.importorskip("torch")
+    from adapters.module_wrapper.search_mixin import SearchMixin
+
+    checkpoint = SearchMixin._resolve_checkpoint_path()
+    if not checkpoint:
+        pytest.skip("no learned-scorer checkpoint available in this environment")
+
+    SearchMixin._learned_model = None  # bypass class-level cache
+    try:
+        model = SearchMixin._load_learned_model()
+    finally:
+        SearchMixin._learned_model = None
+
+    assert model is not None, (
+        f"checkpoint resolved to {checkpoint} but the model failed to load — "
+        "the learned scorer is silently degrading to multidim"
+    )
+
+
+def test_slot_assignment_loads_when_checkpoint_present():
+    """Same guard for the card builder's slot assignment path."""
+    pytest.importorskip("torch")
+    import gchat.card_builder.slot_assignment as sa
+
+    base = REPO_ROOT / "research" / "trm" / "h2" / "checkpoints"
+    if (
+        not (base / "best_model_unified.pt").exists()
+        and not (base / "best_model_slot.pt").exists()
+    ):
+        pytest.skip("no slot-assignment checkpoint available in this environment")
+
+    sa._cached_model = None  # bypass module-level cache
+    try:
+        model = sa._load_slot_model()
+    finally:
+        sa._cached_model = None
+
+    assert model is not None, (
+        "a slot-assignment checkpoint exists but no model loaded — the card "
+        "builder is silently falling back to heuristic content routing"
+    )

--- a/tests/module/test_search_trm_pipeline.py
+++ b/tests/module/test_search_trm_pipeline.py
@@ -1,0 +1,280 @@
+"""Search + TRM pipeline integration tests.
+
+Tests feature extraction, UnifiedTRN scoring, ranking, and halt convergence
+without requiring Qdrant or real embeddings.
+"""
+
+import pytest
+import torch
+
+from adapters.domain_config import EMAIL_DOMAIN, GCHAT_DOMAIN
+from adapters.unified_trn import (
+    CONTENT_DIM,
+    FEATURE_NAMES_V5,
+    STRUCTURAL_DIM,
+    UnifiedTRN,
+)
+
+
+class TestFeatureExtraction:
+    """Feature extraction produces correct-dim vectors."""
+
+    def test_v5_has_17_features(self):
+        assert len(FEATURE_NAMES_V5) == 17
+
+    def test_structural_dim_matches_features(self):
+        assert STRUCTURAL_DIM == 17
+
+    def test_content_dim_is_384(self):
+        assert CONTENT_DIM == 384
+
+    def test_feature_names_include_content_fields(self):
+        assert "sim_content" in FEATURE_NAMES_V5
+        assert "content_density" in FEATURE_NAMES_V5
+        assert "content_form_alignment" in FEATURE_NAMES_V5
+
+    def test_synthetic_feature_vector(self):
+        """Construct a 17D feature vector from synthetic candidate data."""
+        candidate = {f: 0.5 for f in FEATURE_NAMES_V5}
+        features = [candidate[f] for f in FEATURE_NAMES_V5]
+        assert len(features) == 17
+        assert all(f == 0.5 for f in features)
+
+
+class TestUnifiedTRNSearchMode:
+    """UnifiedTRN search mode returns correct keys."""
+
+    @pytest.fixture
+    def model(self):
+        m = UnifiedTRN(dropout=0.0)
+        m.eval()
+        return m
+
+    def test_search_mode_output_keys(self, model):
+        structural = torch.randn(5, STRUCTURAL_DIM)
+        content = torch.randn(5, CONTENT_DIM)
+        with torch.no_grad():
+            out = model(structural, content, mode="search")
+        assert "form_score" in out
+        assert "content_score" in out
+        assert "halt_prob" in out
+
+    def test_search_mode_shapes(self, model):
+        n = 8
+        structural = torch.randn(n, STRUCTURAL_DIM)
+        content = torch.randn(n, CONTENT_DIM)
+        with torch.no_grad():
+            out = model(structural, content, mode="search")
+        assert out["form_score"].shape == (n, 1)
+        assert out["content_score"].shape == (n, 1)
+        assert out["halt_prob"].shape == (n, 1)
+
+    def test_halt_prob_is_bounded(self, model):
+        """Halt prob should be sigmoid output, in [0, 1]."""
+        structural = torch.randn(10, STRUCTURAL_DIM)
+        content = torch.randn(10, CONTENT_DIM)
+        with torch.no_grad():
+            out = model(structural, content, mode="search")
+            # halt_head already ends in nn.Sigmoid() -- do not squash it again.
+            halt = out["halt_prob"]
+        assert (halt >= 0).all()
+        assert (halt <= 1).all()
+
+
+class TestUnifiedTRNBuildMode:
+    """Build mode uses pool_head only."""
+
+    @pytest.fixture
+    def model(self):
+        m = UnifiedTRN(dropout=0.0)
+        m.eval()
+        return m
+
+    def test_build_mode_output_keys(self, model):
+        structural = torch.zeros(3, STRUCTURAL_DIM)
+        content = torch.randn(3, CONTENT_DIM)
+        with torch.no_grad():
+            out = model(structural, content, mode="build")
+        assert "pool_logits" in out
+
+    def test_build_mode_pool_logits_shape(self, model):
+        n = 4
+        structural = torch.zeros(n, STRUCTURAL_DIM)
+        content = torch.randn(n, CONTENT_DIM)
+        with torch.no_grad():
+            out = model(structural, content, mode="build")
+        assert out["pool_logits"].shape == (n, 5)  # 5 pools
+
+    def test_build_mode_produces_valid_pool_predictions(self, model):
+        """Argmax of pool_logits gives a valid pool index."""
+        structural = torch.zeros(6, STRUCTURAL_DIM)
+        content = torch.randn(6, CONTENT_DIM)
+        with torch.no_grad():
+            out = model(structural, content, mode="build")
+            preds = out["pool_logits"].argmax(dim=-1)
+        assert (preds >= 0).all()
+        assert (preds < 5).all()
+
+
+class TestFullSearchPipeline:
+    """Full pipeline: features -> score -> rank -> verify top result."""
+
+    @pytest.fixture
+    def model(self):
+        m = UnifiedTRN(dropout=0.0)
+        m.eval()
+        return m
+
+    def test_score_and_rank_synthetic_candidates(self, model):
+        """Score synthetic candidates and verify ranking produces sorted output."""
+        n_candidates = 10
+        structural = torch.randn(n_candidates, STRUCTURAL_DIM)
+        content = torch.randn(n_candidates, CONTENT_DIM)
+
+        with torch.no_grad():
+            out = model(structural, content, mode="search")
+            form_scores = out["form_score"].squeeze(-1)
+            content_scores = out["content_score"].squeeze(-1)
+            combined = 0.6 * form_scores + 0.4 * content_scores
+
+        # Ranking should produce valid indices
+        ranked_indices = combined.argsort(descending=True)
+        assert len(ranked_indices) == n_candidates
+        assert set(ranked_indices.tolist()) == set(range(n_candidates))
+
+        # Top score should be >= all others
+        top_idx = ranked_indices[0]
+        assert combined[top_idx] >= combined.max() - 1e-6
+
+    def test_pipeline_with_known_positive(self, model):
+        """Create a candidate set with known positive, verify it's rankable."""
+        n = 5
+        # Create structural features - all similar
+        structural = torch.randn(1, STRUCTURAL_DIM).expand(n, -1).clone()
+        content = torch.randn(1, CONTENT_DIM).expand(n, -1).clone()
+
+        # Make candidate 0 have distinct features
+        structural[0] += 2.0
+        content[0] += 1.0
+
+        with torch.no_grad():
+            out = model(structural, content, mode="search")
+            combined = 0.6 * out["form_score"].squeeze(-1) + 0.4 * out[
+                "content_score"
+            ].squeeze(-1)
+
+        # We can't guarantee candidate 0 is top (random weights), but
+        # the pipeline should produce valid scores for all candidates
+        assert combined.shape == (n,)
+        assert not torch.isnan(combined).any()
+        assert not torch.isinf(combined).any()
+
+
+class TestHaltHeadConvergence:
+    """Halt head convergence: synthetic data triggers varied halt probs."""
+
+    @pytest.fixture
+    def model(self):
+        m = UnifiedTRN(dropout=0.0)
+        m.eval()
+        return m
+
+    def test_halt_probs_have_variance(self, model):
+        """Different inputs should produce different halt probabilities."""
+        structural_list = [torch.randn(1, STRUCTURAL_DIM) for _ in range(20)]
+        content_list = [torch.randn(1, CONTENT_DIM) for _ in range(20)]
+
+        halt_probs = []
+        with torch.no_grad():
+            for s, c in zip(structural_list, content_list):
+                out = model(s, c, mode="search")
+                # halt_head already ends in nn.Sigmoid(). Squashing again
+                # compressed the range into ~[0.5, 0.73] and made this
+                # assertion fail on ~20% of random initialisations.
+                halt_probs.append(out["halt_prob"].item())
+
+        # Should have some variance (not all identical)
+        assert max(halt_probs) - min(halt_probs) > 0.01, (
+            f"Halt probs too uniform: range = {max(halt_probs) - min(halt_probs):.4f}"
+        )
+
+    def test_halt_probs_cover_range(self, model):
+        """With enough random inputs, halt probs should span a reasonable range."""
+        halt_probs = []
+        with torch.no_grad():
+            for _ in range(50):
+                s = torch.randn(1, STRUCTURAL_DIM) * 3  # Amplify to explore range
+                c = torch.randn(1, CONTENT_DIM)
+                out = model(s, c, mode="search")
+                halt_probs.append(out["halt_prob"].item())
+
+        # Should have at least some spread
+        assert len(set(round(h, 2) for h in halt_probs)) > 3, (
+            "Halt probs lack diversity"
+        )
+
+
+class TestAllMode:
+    """mode='all' returns everything."""
+
+    @pytest.fixture
+    def model(self):
+        m = UnifiedTRN(dropout=0.0)
+        m.eval()
+        return m
+
+    def test_all_mode_has_all_keys(self, model):
+        structural = torch.randn(3, STRUCTURAL_DIM)
+        content = torch.randn(3, CONTENT_DIM)
+        with torch.no_grad():
+            out = model(structural, content, mode="all")
+        assert "form_score" in out
+        assert "content_score" in out
+        assert "halt_prob" in out
+        assert "pool_logits" in out
+
+    def test_all_mode_pool_logits_shape(self, model):
+        structural = torch.randn(4, STRUCTURAL_DIM)
+        content = torch.randn(4, CONTENT_DIM)
+        with torch.no_grad():
+            out = model(structural, content, mode="all")
+        assert out["pool_logits"].shape == (4, 5)
+
+
+class TestDomainAwarePipeline:
+    """Pipeline respects domain config for pool vocabulary."""
+
+    def test_gchat_has_5_pools(self):
+        assert GCHAT_DOMAIN.n_pools == 5
+
+    def test_email_has_5_pools(self):
+        assert EMAIL_DOMAIN.n_pools == 5
+
+    def test_pool_logits_match_domain_pool_count(self):
+        model = UnifiedTRN(n_pools=GCHAT_DOMAIN.n_pools, dropout=0.0)
+        model.eval()
+        structural = torch.zeros(2, STRUCTURAL_DIM)
+        content = torch.randn(2, CONTENT_DIM)
+        with torch.no_grad():
+            out = model(structural, content, mode="build")
+        assert out["pool_logits"].shape[1] == GCHAT_DOMAIN.n_pools
+
+    def test_email_domain_model_pool_count(self):
+        model = UnifiedTRN(n_pools=EMAIL_DOMAIN.n_pools, dropout=0.0)
+        model.eval()
+        structural = torch.zeros(2, STRUCTURAL_DIM)
+        content = torch.randn(2, CONTENT_DIM)
+        with torch.no_grad():
+            out = model(structural, content, mode="build")
+        assert out["pool_logits"].shape[1] == EMAIL_DOMAIN.n_pools
+
+    def test_pool_prediction_maps_to_valid_pool_name(self):
+        model = UnifiedTRN(n_pools=GCHAT_DOMAIN.n_pools, dropout=0.0)
+        model.eval()
+        structural = torch.zeros(1, STRUCTURAL_DIM)
+        content = torch.randn(1, CONTENT_DIM)
+        with torch.no_grad():
+            out = model(structural, content, mode="build")
+            pred_idx = out["pool_logits"].argmax(dim=-1).item()
+        pool_name = GCHAT_DOMAIN.pool_names[pred_idx]
+        assert pool_name in GCHAT_DOMAIN.pool_vocab

--- a/tests/module/test_slot_assigner.py
+++ b/tests/module/test_slot_assigner.py
@@ -1,0 +1,659 @@
+"""Unit tests for SlotAffinityNet, DomainConfig, and slot_assignment inference."""
+
+import pytest
+import torch
+
+from adapters.domain_config import (
+    EMAIL_DOMAIN,
+    GCHAT_DOMAIN,
+    DomainConfig,
+    get_domain,
+    get_domain_or_default,
+    list_domains,
+    register_domain,
+    resolve_domain,
+)
+from adapters.slot_assigner import (
+    COMPONENT_TO_POOL,
+    POOL_SPECIFICITY_ORDER,
+    POOL_VOCAB,
+    SlotAffinityNet,
+)
+
+# ── DomainConfig Tests ─────────────────────────────────────────────
+
+
+class TestDomainConfig:
+    """Test the domain configuration system."""
+
+    def test_gchat_domain_has_5_pools(self):
+        assert GCHAT_DOMAIN.n_pools == 5
+
+    def test_email_domain_has_5_pools(self):
+        assert EMAIL_DOMAIN.n_pools == 5
+
+    def test_pool_vocab_ids_are_contiguous(self):
+        """Pool IDs must be 0..n-1 with no gaps — required for nn.Linear output."""
+        for domain in [GCHAT_DOMAIN, EMAIL_DOMAIN]:
+            ids = sorted(domain.pool_vocab.values())
+            assert ids == list(range(domain.n_pools)), (
+                f"{domain.domain_id}: pool IDs {ids} are not contiguous 0..{domain.n_pools - 1}"
+            )
+
+    def test_pool_names_is_inverse_of_pool_vocab(self):
+        for domain in [GCHAT_DOMAIN, EMAIL_DOMAIN]:
+            for name, idx in domain.pool_vocab.items():
+                assert domain.pool_names[idx] == name
+
+    def test_component_to_pool_values_are_valid_pools(self):
+        """Every component must map to a pool that exists in pool_vocab."""
+        for domain in [GCHAT_DOMAIN, EMAIL_DOMAIN]:
+            for comp, pool in domain.component_to_pool.items():
+                assert pool in domain.pool_vocab, (
+                    f"{domain.domain_id}: component '{comp}' maps to "
+                    f"unknown pool '{pool}'"
+                )
+
+    def test_specificity_order_covers_all_pools(self):
+        """Specificity order must include every pool — missing one means it's never routed to."""
+        for domain in [GCHAT_DOMAIN, EMAIL_DOMAIN]:
+            missing = set(domain.pool_vocab) - set(domain.specificity_order)
+            assert not missing, (
+                f"{domain.domain_id}: pools missing from specificity_order: {missing}"
+            )
+
+    def test_specificity_order_has_no_extras(self):
+        """No phantom pools in specificity order."""
+        for domain in [GCHAT_DOMAIN, EMAIL_DOMAIN]:
+            extras = set(domain.specificity_order) - set(domain.pool_vocab)
+            assert not extras, (
+                f"{domain.domain_id}: unknown pools in specificity_order: {extras}"
+            )
+
+    def test_domain_config_is_frozen(self):
+        with pytest.raises(AttributeError):
+            GCHAT_DOMAIN.domain_id = "hacked"
+
+    def test_rewrap_rules_reference_valid_pools(self):
+        """Rewrap rules should only define rules for pools that exist."""
+        for domain in [GCHAT_DOMAIN, EMAIL_DOMAIN]:
+            for pool in domain.rewrap_rules:
+                assert pool in domain.pool_vocab, (
+                    f"{domain.domain_id}: rewrap rule for unknown pool '{pool}'"
+                )
+
+
+class TestDomainRegistry:
+    """Test registry lookup and resolution."""
+
+    def test_list_domains_includes_gchat_and_email(self):
+        domains = list_domains()
+        assert "gchat" in domains
+        assert "email" in domains
+
+    def test_get_domain_returns_correct_config(self):
+        assert get_domain("gchat") is GCHAT_DOMAIN
+        assert get_domain("email") is EMAIL_DOMAIN
+
+    def test_get_domain_unknown_raises(self):
+        with pytest.raises(KeyError):
+            get_domain("nonexistent_domain_xyz")
+
+    def test_get_domain_or_default_falls_back_to_gchat(self):
+        assert get_domain_or_default(None) is GCHAT_DOMAIN
+        assert get_domain_or_default("nonexistent") is GCHAT_DOMAIN
+
+    def test_register_domain_adds_new(self):
+        custom = DomainConfig(
+            domain_id="test_custom_xyz",
+            pool_vocab={"a": 0, "b": 1},
+            component_to_pool={"A": "a"},
+            specificity_order=["b", "a"],
+        )
+        register_domain(custom)
+        assert get_domain("test_custom_xyz") is custom
+        # Cleanup
+        from adapters.domain_config import _DOMAIN_REGISTRY
+
+        del _DOMAIN_REGISTRY["test_custom_xyz"]
+
+
+class TestDomainFromCheckpoint:
+    """Test reconstructing DomainConfig from checkpoint metadata."""
+
+    def test_from_checkpoint_with_full_metadata(self):
+        ckpt = {
+            "domain_id": "gchat",
+            "pool_vocab": {
+                "buttons": 0,
+                "content_texts": 1,
+                "grid_items": 2,
+                "chips": 3,
+                "carousel_cards": 4,
+            },
+            "component_to_pool": {
+                "Button": "buttons",
+                "DecoratedText": "content_texts",
+            },
+            "specificity_order": [
+                "chips",
+                "grid_items",
+                "carousel_cards",
+                "buttons",
+                "content_texts",
+            ],
+        }
+        config = DomainConfig.from_checkpoint(ckpt)
+        assert config is not None
+        assert config.domain_id == "gchat"
+        assert config.n_pools == 5
+        assert config.component_to_pool["Button"] == "buttons"
+
+    def test_from_checkpoint_without_domain_id_returns_none(self):
+        """Checkpoints without domain_id should NOT produce a DomainConfig."""
+        ckpt = {"pool_vocab": {"a": 0}, "model_type": "unified_trn"}
+        assert DomainConfig.from_checkpoint(ckpt) is None
+
+    def test_from_checkpoint_without_pool_vocab_returns_none(self):
+        ckpt = {"domain_id": "gchat", "model_type": "unified_trn"}
+        assert DomainConfig.from_checkpoint(ckpt) is None
+
+    def test_from_checkpoint_infers_specificity_from_vocab_keys(self):
+        """If specificity_order is missing, it should default to pool_vocab key order."""
+        ckpt = {
+            "domain_id": "test_infer",
+            "pool_vocab": {"alpha": 0, "beta": 1},
+        }
+        config = DomainConfig.from_checkpoint(ckpt)
+        assert config is not None
+        assert set(config.specificity_order) == {"alpha", "beta"}
+
+    def test_resolve_domain_prefers_checkpoint_over_explicit(self):
+        ckpt = {
+            "domain_id": "email",
+            "pool_vocab": dict(EMAIL_DOMAIN.pool_vocab),
+        }
+        config = resolve_domain(checkpoint=ckpt, domain_id="gchat")
+        # Checkpoint should win
+        assert config.domain_id == "email"
+
+    def test_resolve_domain_falls_back_to_explicit(self):
+        config = resolve_domain(checkpoint={}, domain_id="email")
+        assert config.domain_id == "email"
+
+    def test_resolve_domain_falls_back_to_gchat(self):
+        config = resolve_domain(checkpoint={}, domain_id=None)
+        assert config.domain_id == "gchat"
+
+    def test_resolve_domain_with_no_args(self):
+        config = resolve_domain()
+        assert config.domain_id == "gchat"
+
+
+class TestDomainRewrap:
+    """Test domain-aware item rewrapping."""
+
+    def test_gchat_rewrap_to_buttons_adds_url(self):
+        result = GCHAT_DOMAIN.rewrap_item({"text": "Click"}, "content_texts", "buttons")
+        assert result["text"] == "Click"
+        assert result["url"] == ""
+
+    def test_gchat_rewrap_to_chips_uses_label_field(self):
+        result = GCHAT_DOMAIN.rewrap_item({"text": "Tag"}, "content_texts", "chips")
+        assert result["label"] == "Tag"
+
+    def test_gchat_rewrap_to_content_texts_sets_wrapText(self):
+        result = GCHAT_DOMAIN.rewrap_item("Hello", "buttons", "content_texts")
+        assert result["text"] == "Hello"
+        assert result["wrapText"] is True
+
+    def test_gchat_rewrap_preserves_existing_fields(self):
+        item = {"text": "Deploy", "icon": "rocket", "url": "http://x.com"}
+        result = GCHAT_DOMAIN.rewrap_item(item, "buttons", "content_texts")
+        assert result["icon"] == "rocket"
+        assert result["url"] == "http://x.com"
+
+    def test_gchat_rewrap_does_not_overwrite_existing_url(self):
+        """setdefault should not overwrite an existing url."""
+        item = {"text": "Go", "url": "http://real.com"}
+        result = GCHAT_DOMAIN.rewrap_item(item, "content_texts", "buttons")
+        assert result["url"] == "http://real.com"
+
+    def test_email_rewrap_content_pool(self):
+        result = EMAIL_DOMAIN.rewrap_item({"text": "Hello world"}, "chrome", "content")
+        assert result["text"] == "Hello world"
+
+    def test_rewrap_with_no_rules_falls_back_to_text(self):
+        """Domain with no rewrap rules should still produce a text field."""
+        bare = DomainConfig(
+            domain_id="bare",
+            pool_vocab={"a": 0, "b": 1},
+            component_to_pool={},
+            specificity_order=["a", "b"],
+        )
+        result = bare.rewrap_item("hello", "a", "b")
+        assert result["text"] == "hello"
+
+    def test_rewrap_extracts_text_from_multiple_fields(self):
+        """Should try text, title, label, subtitle, styled in order."""
+        assert GCHAT_DOMAIN.rewrap_item({"title": "T"}, "a", "buttons")["text"] == "T"
+        assert GCHAT_DOMAIN.rewrap_item({"label": "L"}, "a", "buttons")["text"] == "L"
+        assert (
+            GCHAT_DOMAIN.rewrap_item({"subtitle": "S"}, "a", "buttons")["text"] == "S"
+        )
+
+    def test_rewrap_empty_dict_gets_empty_text(self):
+        result = GCHAT_DOMAIN.rewrap_item({}, "a", "buttons")
+        assert result["text"] == ""
+
+
+# ── SlotAffinityNet Tests ──────────────────────────────────────────
+
+
+class TestSlotAffinityNet:
+    """Test the model architecture."""
+
+    def test_forward_shape(self):
+        model = SlotAffinityNet(content_dim=384, n_slot_types=5, hidden=32)
+        content = torch.randn(5, 384)
+        output = model(content)
+        assert output.shape == (5, 5)
+
+    def test_score_all_slots_matches_forward(self):
+        """forward() and score_all_slots() should return identical results."""
+        model = SlotAffinityNet()
+        model.eval()
+        content = torch.randn(3, 384)
+        with torch.no_grad():
+            fwd = model(content)
+            scores = model.score_all_slots(content)
+        assert torch.allclose(fwd, scores)
+
+    def test_different_inputs_give_different_outputs(self):
+        """Model must not collapse all inputs to the same output."""
+        model = SlotAffinityNet()
+        model.eval()
+        # Two very different embeddings
+        a = torch.ones(1, 384) * 5.0
+        b = torch.ones(1, 384) * -5.0
+        with torch.no_grad():
+            out_a = model(a)
+            out_b = model(b)
+        assert not torch.allclose(out_a, out_b, atol=1e-3), (
+            "Model produces identical outputs for very different inputs"
+        )
+
+    def test_custom_n_pools(self):
+        """SlotAffinityNet should work with non-default pool count."""
+        model = SlotAffinityNet(n_slot_types=8)
+        content = torch.randn(2, 384)
+        output = model(content)
+        assert output.shape == (2, 8)
+
+    def test_deterministic_eval(self):
+        model = SlotAffinityNet()
+        model.eval()
+        content = torch.randn(2, 384)
+        with torch.no_grad():
+            s1 = model.score_all_slots(content)
+            s2 = model.score_all_slots(content)
+        assert torch.allclose(s1, s2)
+
+    def test_gradient_flows(self):
+        """Verify gradients flow through the model (trainability check)."""
+        model = SlotAffinityNet()
+        model.train()
+        content = torch.randn(4, 384)
+        target = torch.tensor([0, 1, 2, 3])
+        logits = model(content)
+        loss = torch.nn.functional.cross_entropy(logits, target)
+        loss.backward()
+        for name, param in model.named_parameters():
+            assert param.grad is not None, f"No gradient for {name}"
+            assert param.grad.abs().sum() > 0, f"Zero gradient for {name}"
+
+
+class TestSlotConstants:
+    """Test backward-compat constants are consistent with DomainConfig."""
+
+    def test_pool_vocab_matches_gchat_domain(self):
+        assert POOL_VOCAB == dict(GCHAT_DOMAIN.pool_vocab)
+
+    def test_component_to_pool_matches_gchat_domain(self):
+        assert COMPONENT_TO_POOL == dict(GCHAT_DOMAIN.component_to_pool)
+
+    def test_specificity_order_matches_gchat_domain(self):
+        assert POOL_SPECIFICITY_ORDER == list(GCHAT_DOMAIN.specificity_order)
+
+    def test_all_components_map_to_existing_pools(self):
+        for comp, pool in COMPONENT_TO_POOL.items():
+            assert pool in POOL_VOCAB, f"{comp} maps to unknown pool '{pool}'"
+
+    def test_specificity_order_no_duplicates(self):
+        assert len(POOL_SPECIFICITY_ORDER) == len(set(POOL_SPECIFICITY_ORDER))
+
+
+# ── Slot Assignment Integration Tests ──────────────────────────────
+
+
+class TestSlotAssignment:
+    """Test the inference glue functions."""
+
+    def test_extract_item_text_string(self):
+        from gchat.card_builder.slot_assignment import _extract_item_text
+
+        assert _extract_item_text("hello") == "hello"
+
+    def test_extract_item_text_dict_priority(self):
+        """text field should take priority over title, label, etc."""
+        from gchat.card_builder.slot_assignment import _extract_item_text
+
+        item = {"text": "primary", "title": "secondary", "label": "tertiary"}
+        assert _extract_item_text(item) == "primary"
+
+    def test_extract_item_text_fallback_order(self):
+        from gchat.card_builder.slot_assignment import _extract_item_text
+
+        assert _extract_item_text({"title": "T"}) == "T"
+        assert _extract_item_text({"label": "L"}) == "L"
+        assert _extract_item_text({"subtitle": "S"}) == "S"
+
+    def test_extract_item_text_empty(self):
+        from gchat.card_builder.slot_assignment import _extract_item_text
+
+        assert _extract_item_text({}) == ""
+        assert _extract_item_text(42) == ""
+        assert _extract_item_text(None) == ""
+
+    def test_rewrap_uses_domain_config(self):
+        """Rewrap should use the loaded DomainConfig, not hardcoded rules."""
+        from gchat.card_builder.slot_assignment import _rewrap_item
+
+        result = _rewrap_item({"text": "Test"}, "content_texts", "chips")
+        assert result["label"] == "Test"
+        assert "url" in result
+
+    def test_get_constants_returns_domain_values(self):
+        from gchat.card_builder.slot_assignment import _get_constants
+
+        vocab, comp_to_pool, spec_order = _get_constants()
+        assert isinstance(vocab, dict)
+        assert len(vocab) > 0
+        # All spec_order entries must be in vocab
+        for pool in spec_order:
+            assert pool in vocab
+        # All comp_to_pool values must be in vocab
+        for pool in comp_to_pool.values():
+            assert pool in vocab
+
+    def test_reassign_no_model_returns_original(self):
+        """Without a model checkpoint, reassign should return original."""
+        import gchat.card_builder.slot_assignment as sa
+        from gchat.card_builder.slot_assignment import reassign_supply_map
+
+        old_attempted = sa._model_load_attempted
+        old_model = sa._cached_model
+        old_domain = sa._cached_domain_config
+        sa._model_load_attempted = True
+        sa._cached_model = None
+
+        try:
+            supply_map = {
+                "buttons": [{"text": "Deploy"}],
+                "content_texts": [{"text": "Status"}],
+            }
+            result = reassign_supply_map(supply_map, {"Button": 1, "DecoratedText": 1})
+            assert result is supply_map
+        finally:
+            sa._model_load_attempted = old_attempted
+            sa._cached_model = old_model
+            sa._cached_domain_config = old_domain
+
+    def test_reassign_single_item_returns_original(self):
+        """Pools with 0-1 total items should skip reassignment."""
+        import gchat.card_builder.slot_assignment as sa
+        from gchat.card_builder.slot_assignment import reassign_supply_map
+
+        old_attempted = sa._model_load_attempted
+        old_model = sa._cached_model
+        old_domain = sa._cached_domain_config
+        sa._model_load_attempted = True
+        sa._cached_model = None
+
+        try:
+            supply_map = {"buttons": [{"text": "Deploy"}], "content_texts": []}
+            result = reassign_supply_map(supply_map, {"Button": 1})
+            assert result is supply_map
+        finally:
+            sa._model_load_attempted = old_attempted
+            sa._cached_model = old_model
+            sa._cached_domain_config = old_domain
+
+    def test_reassign_with_mock_model_routes_items(self):
+        """With a mock model, items should be routed by neural scores."""
+        import gchat.card_builder.slot_assignment as sa
+        from gchat.card_builder.slot_assignment import reassign_supply_map
+
+        # Save state
+        old_attempted = sa._model_load_attempted
+        old_model = sa._cached_model
+        old_type = sa._cached_model_type
+        old_domain = sa._cached_domain_config
+
+        try:
+            # Create a mock model that always predicts "chips" (index 3)
+            class MockModel:
+                def __call__(self, structural, content, mode="build"):
+                    batch = content.shape[0]
+                    logits = torch.zeros(batch, 5)
+                    logits[:, 3] = 10.0  # strongly prefer chips
+                    return {"pool_logits": logits}
+
+            sa._model_load_attempted = True
+            sa._cached_model = MockModel()
+            sa._cached_model_type = "unified"
+            sa._cached_domain_config = GCHAT_DOMAIN
+
+            supply_map = {
+                "buttons": [],
+                "content_texts": [
+                    {"text": "Item 1"},
+                    {"text": "Item 2"},
+                    {"text": "Item 3"},
+                ],
+                "chips": [],
+                "grid_items": [],
+                "carousel_cards": [],
+            }
+            demands = {"Chip": 2, "DecoratedText": 1}
+            result = reassign_supply_map(supply_map, demands, wrapper=None)
+
+            # With demand for 2 chips and model strongly preferring chips,
+            # at least some items should move to chips
+            total_items = sum(len(v) for v in result.values())
+            assert total_items == 3, "Total item count must be preserved"
+
+        finally:
+            sa._model_load_attempted = old_attempted
+            sa._cached_model = old_model
+            sa._cached_model_type = old_type
+            sa._cached_domain_config = old_domain
+
+    def test_reassign_preserves_total_item_count(self):
+        """Reassignment must never lose or duplicate items."""
+        import gchat.card_builder.slot_assignment as sa
+        from gchat.card_builder.slot_assignment import reassign_supply_map
+
+        old_attempted = sa._model_load_attempted
+        old_model = sa._cached_model
+        old_type = sa._cached_model_type
+        old_domain = sa._cached_domain_config
+
+        try:
+            # Mock that spreads items across pools
+            class SpreadModel:
+                def __call__(self, structural, content, mode="build"):
+                    batch = content.shape[0]
+                    logits = torch.randn(batch, 5)  # random routing
+                    return {"pool_logits": logits}
+
+            sa._model_load_attempted = True
+            sa._cached_model = SpreadModel()
+            sa._cached_model_type = "unified"
+            sa._cached_domain_config = GCHAT_DOMAIN
+
+            supply_map = {
+                "buttons": [{"text": f"btn_{i}"} for i in range(3)],
+                "content_texts": [{"text": f"ct_{i}"} for i in range(4)],
+                "chips": [{"text": f"chip_{i}"} for i in range(2)],
+                "grid_items": [],
+                "carousel_cards": [],
+            }
+            demands = {"Button": 2, "DecoratedText": 3, "Chip": 2, "GridItem": 2}
+            result = reassign_supply_map(supply_map, demands, wrapper=None)
+
+            original_count = 3 + 4 + 2
+            result_count = sum(len(v) for v in result.values() if isinstance(v, list))
+            assert result_count == original_count, (
+                f"Item count changed: {original_count} -> {result_count}"
+            )
+        finally:
+            sa._model_load_attempted = old_attempted
+            sa._cached_model = old_model
+            sa._cached_model_type = old_type
+            sa._cached_domain_config = old_domain
+
+    def test_reassign_pinned_items_stay_in_place(self):
+        """Items in a pool that's demanded should be pinned, not rerouted."""
+        import gchat.card_builder.slot_assignment as sa
+        from gchat.card_builder.slot_assignment import reassign_supply_map
+
+        old_attempted = sa._model_load_attempted
+        old_model = sa._cached_model
+        old_type = sa._cached_model_type
+        old_domain = sa._cached_domain_config
+
+        try:
+            # Model that would route everything to grid_items if allowed
+            class GridModel:
+                def __call__(self, structural, content, mode="build"):
+                    batch = content.shape[0]
+                    logits = torch.zeros(batch, 5)
+                    logits[:, 2] = 100.0  # grid_items
+                    return {"pool_logits": logits}
+
+            sa._model_load_attempted = True
+            sa._cached_model = GridModel()
+            sa._cached_model_type = "unified"
+            sa._cached_domain_config = GCHAT_DOMAIN
+
+            supply_map = {
+                "buttons": [{"text": "btn_1"}, {"text": "btn_2"}],
+                "content_texts": [{"text": "extra_1"}, {"text": "extra_2"}],
+                "chips": [],
+                "grid_items": [],
+                "carousel_cards": [],
+            }
+            # Demand 2 buttons — so both btn items should be pinned
+            demands = {"Button": 2, "GridItem": 2}
+            result = reassign_supply_map(supply_map, demands, wrapper=None)
+
+            # Buttons should be pinned (demand matches supply)
+            assert len(result["buttons"]) == 2, (
+                f"Pinned buttons should stay: got {len(result['buttons'])}"
+            )
+            # The extra content_texts should be rerouted to grid_items
+            assert len(result["grid_items"]) == 2
+
+        finally:
+            sa._model_load_attempted = old_attempted
+            sa._cached_model = old_model
+            sa._cached_model_type = old_type
+            sa._cached_domain_config = old_domain
+
+
+class TestSlotAssignmentWithDomainConfig:
+    """Test reassign_supply_map with explicit domain_config parameter."""
+
+    def test_reassign_with_gchat_domain(self):
+        """Using domain_config=GCHAT_DOMAIN preserves gchat behavior."""
+        from unittest.mock import patch
+
+        from gchat.card_builder.slot_assignment import reassign_supply_map
+
+        supply_map = {
+            "buttons": ["Click me"],
+            "content_texts": ["Hello"],
+            "grid_items": [],
+            "chips": [],
+            "carousel_cards": [],
+        }
+        demands = {"Button": 1, "DecoratedText": 1}
+
+        with patch(
+            "gchat.card_builder.slot_assignment._load_slot_model", return_value=None
+        ):
+            result = reassign_supply_map(
+                supply_map, demands, domain_config=GCHAT_DOMAIN
+            )
+            assert isinstance(result, dict)
+            assert "buttons" in result
+            assert "content_texts" in result
+
+    def test_reassign_with_email_domain(self):
+        """Using domain_config=EMAIL_DOMAIN uses email pool vocab."""
+        from unittest.mock import patch
+
+        from gchat.card_builder.slot_assignment import reassign_supply_map
+
+        supply_map = {
+            "content": ["Welcome text"],
+            "layout": [],
+            "chrome": [],
+            "structure": [],
+            "interactive": [],
+        }
+        demands = {"TextBlock": 1}
+
+        with patch(
+            "gchat.card_builder.slot_assignment._load_slot_model", return_value=None
+        ):
+            result = reassign_supply_map(
+                supply_map, demands, domain_config=EMAIL_DOMAIN
+            )
+            assert isinstance(result, dict)
+            assert "content" in result
+
+    def test_reassign_none_domain_preserves_default(self):
+        """domain_config=None falls back to gchat default."""
+        from unittest.mock import patch
+
+        from gchat.card_builder.slot_assignment import reassign_supply_map
+
+        supply_map = {
+            "buttons": [],
+            "content_texts": ["text"],
+            "grid_items": [],
+            "chips": [],
+            "carousel_cards": [],
+        }
+        demands = {}
+
+        with patch(
+            "gchat.card_builder.slot_assignment._load_slot_model", return_value=None
+        ):
+            result = reassign_supply_map(supply_map, demands, domain_config=None)
+            assert isinstance(result, dict)
+
+    def test_email_domain_pools_differ_from_gchat(self):
+        """Email and gchat domains have different pool vocabularies."""
+        assert set(EMAIL_DOMAIN.pool_vocab.keys()) != set(
+            GCHAT_DOMAIN.pool_vocab.keys()
+        )
+        assert "content" in EMAIL_DOMAIN.pool_vocab
+        assert "buttons" in GCHAT_DOMAIN.pool_vocab
+
+    def test_domain_config_n_pools_match(self):
+        """Both domains have 5 pools for compatibility with UnifiedTRN."""
+        assert GCHAT_DOMAIN.n_pools == 5
+        assert EMAIL_DOMAIN.n_pools == 5

--- a/tests/module/test_slot_pin_policy.py
+++ b/tests/module/test_slot_pin_policy.py
@@ -1,0 +1,187 @@
+"""Tests for the slot-assignment pinning policy.
+
+`reassign_supply_map` historically pinned any item whose *source* pool still had
+unmet demand, without consulting the model. Because the supply_map is normally
+built to match DSL demand, that guard was active almost always and the model was
+consulted almost never -- misrouted content stayed misrouted.
+
+SLOT_PIN_MODE=confidence lets the model release an item for rerouting when it
+prefers a different, still-demanded pool. Default stays "always" (legacy).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from adapters.domain_config import GCHAT_DOMAIN
+from gchat.card_builder.slot_assignment import _pin_policy, _should_release
+
+VOCAB = GCHAT_DOMAIN.pool_vocab
+
+
+@pytest.fixture(autouse=True)
+def _clear_pin_env(monkeypatch):
+    monkeypatch.delenv("SLOT_PIN_MODE", raising=False)
+    monkeypatch.delenv("SLOT_REROUTE_CONFIDENCE", raising=False)
+
+
+# ── Policy resolution ────────────────────────────────────────────────
+
+
+def test_default_policy_is_legacy_always():
+    mode, threshold = _pin_policy()
+    assert mode == "always"
+    assert threshold == pytest.approx(0.70)
+
+
+def test_confidence_mode_opt_in(monkeypatch):
+    monkeypatch.setenv("SLOT_PIN_MODE", "confidence")
+    monkeypatch.setenv("SLOT_REROUTE_CONFIDENCE", "0.85")
+    mode, threshold = _pin_policy()
+    assert mode == "confidence"
+    assert threshold == pytest.approx(0.85)
+
+
+@pytest.mark.parametrize("bad", ["", "yolo", "CONFIDENCE_PLUS"])
+def test_unknown_mode_falls_back_to_always(monkeypatch, bad):
+    monkeypatch.setenv("SLOT_PIN_MODE", bad)
+    assert _pin_policy()[0] == "always"
+
+
+def test_mode_is_case_and_space_insensitive(monkeypatch):
+    monkeypatch.setenv("SLOT_PIN_MODE", "  Confidence  ")
+    assert _pin_policy()[0] == "confidence"
+
+
+def test_invalid_threshold_falls_back(monkeypatch):
+    monkeypatch.setenv("SLOT_REROUTE_CONFIDENCE", "not-a-number")
+    assert _pin_policy()[1] == pytest.approx(0.70)
+
+
+@pytest.mark.parametrize("raw,expected", [("-1", 0.0), ("5", 1.0)])
+def test_threshold_is_clamped(monkeypatch, raw, expected):
+    monkeypatch.setenv("SLOT_REROUTE_CONFIDENCE", raw)
+    assert _pin_policy()[1] == pytest.approx(expected)
+
+
+# ── Release decision ─────────────────────────────────────────────────
+
+
+def _logits(**pool_weights):
+    """Build a logit vector over the gchat pools."""
+    torch = pytest.importorskip("torch")
+    vec = [0.0] * len(VOCAB)
+    for pool, weight in pool_weights.items():
+        vec[VOCAB[pool]] = weight
+    return torch.tensor(vec)
+
+
+def test_releases_when_model_confidently_prefers_a_demanded_pool():
+    scores = _logits(buttons=12.0)
+    assert _should_release(scores, "content_texts", {"buttons": 1}, VOCAB, 0.7)
+
+
+def test_pins_when_model_agrees_with_current_pool():
+    scores = _logits(content_texts=12.0)
+    assert not _should_release(scores, "content_texts", {"buttons": 1}, VOCAB, 0.7)
+
+
+def test_pins_when_preferred_pool_has_no_unmet_demand():
+    """Anti-starvation: never pull an item out toward a pool with no free slot."""
+    scores = _logits(buttons=12.0)
+    assert not _should_release(scores, "content_texts", {"buttons": 0}, VOCAB, 0.7)
+    assert not _should_release(scores, "content_texts", {}, VOCAB, 0.7)
+
+
+def test_pins_when_confidence_below_threshold():
+    scores = _logits(buttons=0.15)  # near-uniform -> low max prob
+    assert not _should_release(scores, "content_texts", {"buttons": 1}, VOCAB, 0.7)
+
+
+def test_pins_when_scores_missing():
+    assert not _should_release(None, "content_texts", {"buttons": 1}, VOCAB, 0.7)
+
+
+def test_pins_when_scoring_raises():
+    """A malformed score tensor must never break card building."""
+
+    class Exploding:
+        def argmax(self):
+            raise RuntimeError("boom")
+
+    assert not _should_release(Exploding(), "content_texts", {"buttons": 1}, VOCAB, 0.7)
+
+
+# ── End-to-end through reassign_supply_map ───────────────────────────
+
+
+def _misrouted_supply_map():
+    return {
+        "content_texts": ["Deploy to Production", "All systems operational."],
+        "buttons": ["The deployment pipeline completed without errors.", "View Logs"],
+        "chips": [],
+        "grid_items": [],
+        "carousel_cards": [],
+    }
+
+
+def _texts(pool):
+    return [x if isinstance(x, str) else x.get("text") for x in pool]
+
+
+def _reassign():
+    from gchat.card_builder.slot_assignment import _load_slot_model
+
+    pytest.importorskip("torch")
+    if _load_slot_model() is None:
+        pytest.skip("no slot-assignment checkpoint available in this environment")
+
+    from gchat.card_builder.slot_assignment import reassign_supply_map
+
+    supply = _misrouted_supply_map()
+    out = reassign_supply_map(
+        supply,
+        {"ButtonList": 2, "TextParagraph": 2},
+        domain_config=GCHAT_DOMAIN,
+    )
+    return supply, out
+
+
+def test_always_mode_leaves_misrouted_content_in_place():
+    """Documents the legacy behaviour: counts match demand, so nothing moves."""
+    supply, out = _reassign()
+    assert out == supply
+
+
+def test_confidence_mode_reroutes_misplaced_items(monkeypatch):
+    monkeypatch.setenv("SLOT_PIN_MODE", "confidence")
+    supply, out = _reassign()
+
+    assert out != supply
+    assert "Deploy to Production" in _texts(out["buttons"])
+    assert "View Logs" in _texts(out["buttons"])
+    assert "All systems operational." in _texts(out["content_texts"])
+    assert "The deployment pipeline completed without errors." in _texts(
+        out["content_texts"]
+    )
+
+
+def test_confidence_mode_preserves_pool_counts(monkeypatch):
+    """Rerouting must not starve a pool the DSL asked for."""
+    monkeypatch.setenv("SLOT_PIN_MODE", "confidence")
+    supply, out = _reassign()
+
+    for pool in ("buttons", "content_texts"):
+        assert len(out[pool]) == len(supply[pool]) == 2
+
+    total_before = sum(len(v) for v in supply.values())
+    total_after = sum(len(v) for v in out.values())
+    assert total_after == total_before
+
+
+def test_unreachable_threshold_pins_everything(monkeypatch):
+    """pool_head probs top out around 0.96, so 0.999 must release nothing."""
+    monkeypatch.setenv("SLOT_PIN_MODE", "confidence")
+    monkeypatch.setenv("SLOT_REROUTE_CONFIDENCE", "0.999")
+    supply, out = _reassign()
+    assert out == supply

--- a/tests/module/test_unified_trn.py
+++ b/tests/module/test_unified_trn.py
@@ -1,0 +1,307 @@
+"""Unit tests for UnifiedTRN model and multi-domain support."""
+
+import pytest
+import torch
+
+from adapters.domain_config import (
+    EMAIL_DOMAIN,
+    GCHAT_DOMAIN,
+    DomainConfig,
+)
+from adapters.slot_assigner import POOL_VOCAB
+from adapters.unified_trn import FEATURE_NAMES_V5, UnifiedTRN
+
+
+class TestUnifiedTRNArchitecture:
+    """Test the unified model architecture correctness."""
+
+    def test_search_mode_returns_correct_keys(self):
+        model = UnifiedTRN()
+        out = model(torch.randn(5, 17), torch.randn(5, 384), mode="search")
+        assert set(out.keys()) == {"form_score", "content_score", "halt_prob"}
+
+    def test_build_mode_returns_correct_keys(self):
+        model = UnifiedTRN()
+        out = model(torch.zeros(3, 17), torch.randn(3, 384), mode="build")
+        assert set(out.keys()) == {"pool_logits"}
+
+    def test_all_mode_returns_all_keys(self):
+        model = UnifiedTRN()
+        out = model(torch.randn(2, 17), torch.randn(2, 384), mode="all")
+        assert set(out.keys()) == {
+            "form_score",
+            "content_score",
+            "halt_prob",
+            "pool_logits",
+        }
+
+    def test_search_mode_shapes(self):
+        model = UnifiedTRN()
+        out = model(torch.randn(5, 17), torch.randn(5, 384), mode="search")
+        assert out["form_score"].shape == (5, 1)
+        assert out["content_score"].shape == (5, 1)
+        assert out["halt_prob"].shape == (5, 1)
+
+    def test_build_mode_shape_matches_n_pools(self):
+        model = UnifiedTRN(n_pools=7)
+        out = model(torch.zeros(3, 17), torch.randn(3, 384), mode="build")
+        assert out["pool_logits"].shape == (3, 7)
+
+    def test_halt_prob_bounded_0_1(self):
+        model = UnifiedTRN()
+        model.eval()
+        # Test with extreme inputs
+        for val in [-100.0, 0.0, 100.0]:
+            structural = torch.full((10, 17), val)
+            content = torch.full((10, 384), val)
+            with torch.no_grad():
+                out = model(structural, content, mode="search")
+            probs = out["halt_prob"]
+            assert (probs >= 0).all() and (probs <= 1).all(), (
+                f"halt_prob out of [0,1] with input={val}: "
+                f"min={probs.min():.4f}, max={probs.max():.4f}"
+            )
+
+    def test_parameter_count_reasonable(self):
+        model = UnifiedTRN(hidden=64)
+        n = model.count_parameters()
+        assert 20000 < n < 40000, f"Expected ~28.7K params, got {n}"
+
+    def test_deterministic_in_eval_mode(self):
+        model = UnifiedTRN()
+        model.eval()
+        s = torch.randn(3, 17)
+        c = torch.randn(3, 384)
+        with torch.no_grad():
+            out1 = model(s, c, mode="all")
+            out2 = model(s, c, mode="all")
+        for key in out1:
+            assert torch.allclose(out1[key], out2[key]), (
+                f"{key} not deterministic in eval"
+            )
+
+    def test_non_deterministic_in_train_mode(self):
+        """Dropout should cause variation in train mode."""
+        model = UnifiedTRN(dropout=0.5)  # high dropout for visibility
+        model.train()
+        s = torch.randn(20, 17)
+        c = torch.randn(20, 384)
+        results = []
+        for _ in range(5):
+            out = model(s, c, mode="search")
+            results.append(out["form_score"].clone())
+        # At least some runs should differ (extremely unlikely all 5 match with 50% dropout)
+        all_same = all(torch.allclose(results[0], r) for r in results[1:])
+        assert not all_same, "Dropout has no effect in train mode"
+
+
+class TestUnifiedTRNMultiDomain:
+    """Test that UnifiedTRN works with different domain configurations."""
+
+    def test_custom_n_pools(self):
+        """Model should accept arbitrary n_pools (not just 5)."""
+        for n in [2, 4, 8, 12]:
+            model = UnifiedTRN(n_pools=n)
+            out = model(torch.zeros(2, 17), torch.randn(2, 384), mode="build")
+            assert out["pool_logits"].shape == (2, n), f"Failed for n_pools={n}"
+
+    def test_custom_structural_dim(self):
+        """Model should accept different feature dimensions."""
+        model = UnifiedTRN(structural_dim=10, content_dim=128, n_pools=3)
+        out = model(torch.randn(2, 10), torch.randn(2, 128), mode="all")
+        assert out["form_score"].shape == (2, 1)
+        assert out["pool_logits"].shape == (2, 3)
+
+    def test_email_domain_n_pools(self):
+        """Model instantiated with email domain pool count should work."""
+        model = UnifiedTRN(n_pools=EMAIL_DOMAIN.n_pools)
+        out = model(torch.zeros(3, 17), torch.randn(3, 384), mode="build")
+        assert out["pool_logits"].shape == (3, EMAIL_DOMAIN.n_pools)
+
+    def test_n_pools_stored_on_model(self):
+        model = UnifiedTRN(n_pools=7)
+        assert model.n_pools == 7
+
+    def test_pool_head_output_changes_with_n_pools(self):
+        """Different n_pools must produce different output sizes, not silently truncate."""
+        m5 = UnifiedTRN(n_pools=5)
+        m8 = UnifiedTRN(n_pools=8)
+        content = torch.randn(1, 384)
+        struct = torch.zeros(1, 17)
+        o5 = m5(struct, content, mode="build")["pool_logits"]
+        o8 = m8(struct, content, mode="build")["pool_logits"]
+        assert o5.shape[1] == 5
+        assert o8.shape[1] == 8
+
+
+class TestUnifiedTRNGradients:
+    """Test that all heads receive gradients during training."""
+
+    def test_form_head_gradients(self):
+        model = UnifiedTRN()
+        model.train()
+        out = model(torch.randn(4, 17), torch.randn(4, 384), mode="search")
+        loss = out["form_score"].sum()
+        loss.backward()
+        # form_head params should have gradients
+        for name, p in model.form_head.named_parameters():
+            assert p.grad is not None and p.grad.abs().sum() > 0, (
+                f"form_head.{name} has no gradient"
+            )
+
+    def test_content_head_gradients(self):
+        model = UnifiedTRN()
+        model.train()
+        out = model(torch.randn(4, 17), torch.randn(4, 384), mode="search")
+        loss = out["content_score"].sum()
+        loss.backward()
+        for name, p in model.content_head.named_parameters():
+            assert p.grad is not None and p.grad.abs().sum() > 0, (
+                f"content_head.{name} has no gradient"
+            )
+
+    def test_pool_head_gradients(self):
+        model = UnifiedTRN()
+        model.train()
+        out = model(torch.zeros(4, 17), torch.randn(4, 384), mode="build")
+        target = torch.tensor([0, 1, 2, 3])
+        loss = torch.nn.functional.cross_entropy(out["pool_logits"], target)
+        loss.backward()
+        for name, p in model.pool_head.named_parameters():
+            assert p.grad is not None and p.grad.abs().sum() > 0, (
+                f"pool_head.{name} has no gradient"
+            )
+
+    def test_halt_head_gradients(self):
+        model = UnifiedTRN()
+        model.train()
+        out = model(torch.randn(4, 17), torch.randn(4, 384), mode="search")
+        loss = out["halt_prob"].sum()
+        loss.backward()
+        for name, p in model.halt_head.named_parameters():
+            assert p.grad is not None and p.grad.abs().sum() > 0, (
+                f"halt_head.{name} has no gradient"
+            )
+
+    def test_backbone_receives_gradients_from_all_heads(self):
+        """Backbone should get gradients whether loss comes from form, content, pool, or halt."""
+        for mode, key in [
+            ("search", "form_score"),
+            ("search", "content_score"),
+            ("build", "pool_logits"),
+            ("search", "halt_prob"),
+        ]:
+            model = UnifiedTRN()
+            model.train()
+            model.zero_grad()
+            out = model(torch.randn(4, 17), torch.randn(4, 384), mode=mode)
+            if key == "pool_logits":
+                loss = torch.nn.functional.cross_entropy(
+                    out[key], torch.tensor([0, 1, 2, 3])
+                )
+            else:
+                loss = out[key].sum()
+            loss.backward()
+            backbone_grads = sum(
+                p.grad.abs().sum().item()
+                for p in model.backbone.parameters()
+                if p.grad is not None
+            )
+            assert backbone_grads > 0, f"Backbone has no gradients from {key}"
+
+
+class TestUnifiedTRNEdgeCases:
+    """Test edge cases and potential failure modes."""
+
+    def test_single_item_batch(self):
+        model = UnifiedTRN()
+        model.eval()
+        with torch.no_grad():
+            out = model(torch.randn(1, 17), torch.randn(1, 384), mode="all")
+        assert out["form_score"].shape == (1, 1)
+        assert out["pool_logits"].shape == (1, 5)
+
+    def test_large_batch(self):
+        model = UnifiedTRN()
+        model.eval()
+        with torch.no_grad():
+            out = model(torch.randn(256, 17), torch.randn(256, 384), mode="all")
+        assert out["form_score"].shape == (256, 1)
+
+    def test_zero_structural_features(self):
+        """Build mode uses zeros for structural — must not produce NaN."""
+        model = UnifiedTRN()
+        model.eval()
+        with torch.no_grad():
+            out = model(torch.zeros(10, 17), torch.randn(10, 384), mode="build")
+        assert not torch.isnan(out["pool_logits"]).any()
+        assert not torch.isinf(out["pool_logits"]).any()
+
+    def test_extreme_input_values(self):
+        """Model should not NaN with extreme inputs."""
+        model = UnifiedTRN()
+        model.eval()
+        for val in [1e6, -1e6, 1e-8]:
+            s = torch.full((2, 17), val)
+            c = torch.full((2, 384), val)
+            with torch.no_grad():
+                out = model(s, c, mode="all")
+            for key, tensor in out.items():
+                assert not torch.isnan(tensor).any(), f"NaN in {key} with input={val}"
+
+    def test_no_output_collapse(self):
+        """Different inputs should produce different outputs — model must not collapse."""
+        model = UnifiedTRN()
+        model.eval()
+        torch.manual_seed(42)
+        inputs = [torch.randn(1, 384) for _ in range(5)]
+        struct = torch.randn(1, 17)
+        scores = []
+        with torch.no_grad():
+            for c in inputs:
+                out = model(struct, c, mode="build")
+                scores.append(out["pool_logits"])
+        # At least some pairs should differ
+        n_different = sum(
+            1
+            for i in range(len(scores))
+            for j in range(i + 1, len(scores))
+            if not torch.allclose(scores[i], scores[j], atol=1e-3)
+        )
+        assert n_different > 0, (
+            "Model collapses all different content inputs to same output"
+        )
+
+
+class TestBackwardCompatibility:
+    """Verify backward compatibility and domain-aware defaults."""
+
+    def test_get_domain_defaults_gchat(self):
+        from adapters.unified_trn import get_domain_defaults
+
+        defaults = get_domain_defaults("gchat")
+        assert defaults["pool_vocab"] == dict(GCHAT_DOMAIN.pool_vocab)
+        assert defaults["component_to_pool"] == dict(GCHAT_DOMAIN.component_to_pool)
+        assert defaults["n_pools"] == GCHAT_DOMAIN.n_pools
+
+    def test_get_domain_defaults_email(self):
+        from adapters.unified_trn import get_domain_defaults
+
+        defaults = get_domain_defaults("email")
+        assert defaults["pool_vocab"] == dict(EMAIL_DOMAIN.pool_vocab)
+        assert defaults["n_pools"] == EMAIL_DOMAIN.n_pools
+
+    def test_feature_names_v5_has_17_features(self):
+        assert len(FEATURE_NAMES_V5) == 17
+
+    def test_default_n_pools(self):
+        model = UnifiedTRN()
+        assert model.n_pools == 5  # DEFAULT_N_POOLS
+
+    def test_custom_n_pools(self):
+        model = UnifiedTRN(n_pools=EMAIL_DOMAIN.n_pools)
+        assert model.n_pools == EMAIL_DOMAIN.n_pools
+
+    def test_structural_dim_matches_features(self):
+        model = UnifiedTRN()
+        assert model.structural_dim == len(FEATURE_NAMES_V5)

--- a/tools/diagnostic-ui/backend/routes/ml_eval.py
+++ b/tools/diagnostic-ui/backend/routes/ml_eval.py
@@ -2058,7 +2058,7 @@ async def search_evaluation():
     if model is None or not val_groups:
         return {"error": "Model or validation data not available"}
 
-    from research.trm.h2.eval_metrics import (
+    from adapters.eval_metrics import (
         evaluate_ranked_results,
         reciprocal_rank,
     )
@@ -2158,7 +2158,7 @@ async def model_comparison():
     if not val_groups:
         return {"error": "Validation data not available"}
 
-    from research.trm.h2.eval_metrics import reciprocal_rank
+    from adapters.eval_metrics import reciprocal_rank
 
     results = {}
 
@@ -2195,7 +2195,7 @@ async def model_comparison():
 
     if unified_path.exists():
         try:
-            from research.trm.h2.unified_trn import UnifiedTRN
+            from adapters.unified_trn import UnifiedTRN
 
             ckpt = torch.load(str(unified_path), map_location="cpu", weights_only=False)
             unified_model = UnifiedTRN(

--- a/uv.lock
+++ b/uv.lock
@@ -1165,7 +1165,7 @@ wheels = [
 
 [[package]]
 name = "google-workspace-unlimited"
-version = "2.3.1"
+version = "2.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiodebug" },


### PR DESCRIPTION
## Summary

Two related changes to the module-wrapper / TRM scorer path, plus the test suite that guards them.

The `research/` tree is internal-only and excluded from the published repo (removed in 59207e9), but production code still imported its model definitions. This PR moves those definitions into `adapters/` and adds a guard test, then adds an opt-in policy switch that lets the learned model actually influence card slot assignment.

## 1. `fix:` vendor TRM model definitions into `adapters/`

Production imported model classes from `research/`:

| file | imported |
|---|---|
| `gchat/card_builder/slot_assignment.py` | `research.trm.h2.unified_trn`, `research.trm.h2.slot_assigner` |
| `adapters/module_wrapper/search_mixin/_learned_model.py` | `research.trm.h2.unified_trn` |
| `tools/diagnostic-ui/backend/routes/ml_eval.py` | `research.trm.h2.eval_metrics`, `research.trm.h2.unified_trn` |

In a clean checkout those raise `ImportError`, and both call sites caught it under a broad `except Exception` that logged a warning and fell back. So the learned scorer silently degraded to `multidim` and slot assignment silently degraded to heuristics. With `SEARCH_MODE=recursive` the learned path is live, so this was a real behavioural regression that surfaced no obvious error.

Now vendored as the source of truth:

- `adapters/unified_trn.py` — `UnifiedTRN` (17D structural + 384D content; form/content/pool/halt heads; ~28.7K params)
- `adapters/slot_assigner.py` — `SlotAffinityNet`
- `adapters/eval_metrics.py` — `evaluate_ranked_results`, `reciprocal_rank`

Training scripts stay in `research/` and import from `adapters/`, so there is one definition instead of two that drift apart.

**Checkpoints are unaffected** — the architecture is unchanged, and model artifacts are fetched from GCS via `MODEL_ARTIFACT_URI` rather than the gitignored checkpoints directory.

Both loaders now catch `ImportError` separately and log at ERROR: a missing model class is a packaging bug, not a normal degradation path, and should be loud.

## 2. `feat:` `SLOT_PIN_MODE` — let the model reroute card content

`reassign_supply_map()` pinned an item to its current pool whenever that pool still had unmet DSL demand. Because supply counts usually line up with demand, the pin fired first and `UnifiedTRN` was **never consulted** — misrouted content stayed misrouted regardless of the model's prediction.

| value | behaviour |
|---|---|
| `always` (default) | legacy — pin whenever the pool is demanded |
| `confidence` | consult the model first; release only when it confidently prefers a different, still-demanded pool |

Releasing hands the slot back to `remaining_demand`, so unassigned items and unmet demand stay balanced and no pool can be starved by a reroute. `_should_release()` fails toward pinning on every guard: no score, model agrees, preferred pool undemanded, or confidence below threshold.

**Default is the existing behaviour, so this is inert unless enabled.**

> [!NOTE]
> **`SLOT_REROUTE_CONFIDENCE` is an on/off switch, not a dial.** Measured on `mw_slot_training_data.json`: `pool_head` is saturated rather than calibrated — `label_smoothing=0.1` over 5 pools caps the true-class target near 0.92, and observed max-probs span only 0.896–0.959 (median 0.928). The top-1-vs-current margin does not separate either: correct-but-moved items scored 0.900–0.905, inside the 0.835–0.910 range of genuine fixes. Below ~0.89 it releases on every disagreement; above ~0.96 it releases nothing. It ships as an escape hatch. Making it a real dial needs a calibrated `pool_head` (temperature scaling, or dropping label smoothing) evaluated against a frozen eval set.

## 3. Tests

`tests/module/test_no_research_imports.py` AST-scans the shipped packages and fails the build on any `research.*` import, so the boundary cannot regress silently. Also adds coverage for `UnifiedTRN`, `SlotAffinityNet`, the pin policy, the search/TRM pipeline, and cross-domain builder behaviour.

```
502 passed, 32 skipped
ruff check . — All checks passed
ruff format --check . — 513 files already formatted
```

Each commit was verified to build and test independently.

## 4. `Release 2.4.0`

`pyproject.toml` and `uv.lock` bumped 2.3.1 → **2.4.0**. Minor rather than patch because
`SLOT_PIN_MODE` is a new feature — though it defaults to the existing behaviour, so upgrading
changes nothing unless opted in. No API changes; checkpoints and model architecture unaffected.

## 5. `docs:` transfer investigation writeup

`docs/TRM_TRANSFER_HANDOFF_2026-07-25.md`, successor to `docs/NEXT_STEPS_2026-04-05.md`.

While testing whether a scorer trained on one wrapped module ranks components on a different one, the training-data generator turned out to embed queries via `embed_multivector_sync`, which takes a *list* of texts and so returns `[1, tokens, dim]`. The batch axis was never unwrapped and only `ndim == 1` was guarded, so MaxSim normalized and reduced along the token axis instead of the embedding axis — inflating every ColBERT feature by ~`sqrt(dim/tokens)` and taking the max over document tokens rather than query tokens. Training and inference were computing different statistics.

Fixing it dropped out-of-distribution features from 9/17 to 4/17 and the worst z-score from −12.5 to −3.4, but transfer still fails for a second, distinct reason: scores saturate in a narrow band, so the reranking is uninformative rather than harmful. Next lever is per-query feature normalization.

The generator fix lives in the gitignored `research/` tree; this doc carries the reasoning and numbers so they aren't lost with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
