### PR TITLE
Release 2.4.1 — never serve one domain's model checkpoint to another domain

### DIFF
--- a/adapters/module_wrapper/search_mixin/_learned_model.py
+++ b/adapters/module_wrapper/search_mixin/_learned_model.py
@@ -39,11 +39,21 @@ def _resolve_checkpoint_path(cls, domain: str | None = None) -> str | None:
                 if os.path.exists(path):
                     logger.debug(f"Using cloud artifact (default): {path}")
                     return path
-            # Try first available
-            for d, path in artifact_paths.items():
-                if os.path.exists(path):
-                    logger.debug(f"Using cloud artifact (domain={d}): {path}")
-                    return path
+            # Try first available -- ONLY when no specific domain was requested.
+            # A model carries its domain's pool vocabulary and component mapping,
+            # so handing an email request a gchat checkpoint produces confident
+            # nonsense rather than a visible failure.
+            if domain is None:
+                for d, path in artifact_paths.items():
+                    if os.path.exists(path):
+                        logger.debug(f"Using cloud artifact (domain={d}): {path}")
+                        return path
+            else:
+                logger.warning(
+                    f"No cloud artifact for domain={domain!r} "
+                    f"(available: {sorted(artifact_paths)}) — refusing to fall back "
+                    "to another domain's model"
+                )
     except ImportError:
         pass  # lifespans not available (e.g., during testing)
 
@@ -56,10 +66,17 @@ def _resolve_checkpoint_path(cls, domain: str | None = None) -> str | None:
                 path = registry[domain]
                 if os.path.exists(path):
                     return path
-            # Fallback to first available in registry
-            for d, path in registry.items():
-                if os.path.exists(path):
-                    return path
+            # Fallback to first available -- same domain-safety rule as above.
+            if domain is None:
+                for d, path in registry.items():
+                    if os.path.exists(path):
+                        return path
+            else:
+                logger.warning(
+                    f"No registry entry for domain={domain!r} "
+                    f"(available: {sorted(registry)}) — refusing to fall back "
+                    "to another domain's model"
+                )
         except _json.JSONDecodeError:
             logger.warning("LEARNED_SCORER_REGISTRY is not valid JSON")
 
@@ -181,6 +198,18 @@ def _load_learned_model(cls, domain: str | None = None):
             "feature_version", 5 if model_type == "unified" else 1
         )
         cls._learned_model_domain = ckpt.get("domain_id")
+
+        # Defence in depth: resolution can hand back the right *path* and still
+        # be the wrong model if the artifact itself was published under the
+        # wrong prefix. The checkpoint's own domain_id is the authority.
+        ckpt_domain = ckpt.get("domain_id")
+        if domain and ckpt_domain and ckpt_domain != domain:
+            logger.warning(
+                f"Checkpoint at {checkpoint_path} is for domain={ckpt_domain!r} "
+                f"but domain={domain!r} was requested. Pool vocabulary and "
+                "component mapping will not match — check how this artifact was "
+                "published."
+            )
 
         if model_type in ("unified", "unified_trn"):
             # UnifiedTRN: dual-encoder with 4 task heads

--- a/config/settings.py
+++ b/config/settings.py
@@ -428,7 +428,12 @@ class Settings(BaseSettings):
         description=(
             "JSON mapping of domain->artifact URI, or single URI for all domains. "
             "Supports gs://, s3://, az://, https:// schemes. "
-            'Example: \'{"gchat": "gs://my-bucket/trm/best_model_unified.pt"}\''
+            'Example: \'{"gchat": "gs://my-bucket/trm/best_model_unified.pt"}\'. '
+            "Only map a domain you have actually trained a model for: a checkpoint "
+            "carries its domain's pool vocabulary and component mapping, so pointing "
+            "two domains at the same file makes one of them score confident nonsense. "
+            "Unmapped domains now resolve to no model rather than borrowing another "
+            "domain's — see tests/module/test_checkpoint_domain_resolution.py."
         ),
         json_schema_extra={"env": "MODEL_ARTIFACT_URI"},
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "google-workspace-unlimited"
-version = "2.4.0"
+version = "2.4.1"
 description = "Comprehensive MCP server for Google Workspace integration - 72+ tools across Gmail, Drive, Docs, Sheets, Slides, Calendar, Forms, Chat, and Photos with OAuth 2.1 + PKCE authentication"
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/module/test_checkpoint_domain_resolution.py
+++ b/tests/module/test_checkpoint_domain_resolution.py
@@ -1,0 +1,117 @@
+"""Guard: a domain must never be served another domain's checkpoint.
+
+Background — this test exists because of a real misconfiguration. MODEL_ARTIFACT_URI
+mapped both "gchat" and "email" to a `best_model_unified.pt`, but the file published
+under the email prefix was a byte-identical copy of the gchat model (its own
+`domain_id` said "gchat"). Anything resolving the email domain silently loaded a
+gchat-trained scorer, carrying gchat's pool vocabulary and component mapping.
+
+Removing the bad entry alone would not have fixed it: `_resolve_checkpoint_path`
+ended each lookup with a "first available" loop that returned *any* artifact
+regardless of the domain asked for, so an email request fell straight back onto
+the gchat model. These tests pin the corrected behaviour:
+
+  1. An explicit domain never falls back to a different domain's artifact.
+  2. Domain-less lookups keep the old first-available convenience.
+  3. An exact domain match still wins.
+  4. A checkpoint whose own domain_id disagrees with the request warns loudly.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from adapters.module_wrapper.search_mixin._learned_model import (
+    _resolve_checkpoint_path,
+)
+
+
+class _Resolver:
+    """Minimal stand-in for the class `_resolve_checkpoint_path` binds to."""
+
+
+def _resolve(domain=None):
+    return _resolve_checkpoint_path.__func__(_Resolver, domain=domain)
+
+
+@pytest.fixture
+def gchat_only(tmp_path, monkeypatch):
+    """A registry that knows about gchat but not email."""
+    ckpt = tmp_path / "gchat.pt"
+    ckpt.write_bytes(b"not-a-real-checkpoint")
+    monkeypatch.setenv("LEARNED_SCORER_REGISTRY", json.dumps({"gchat": str(ckpt)}))
+    monkeypatch.delenv("LEARNED_SCORER_CHECKPOINT", raising=False)
+    return str(ckpt)
+
+
+def test_exact_domain_match_resolves(gchat_only):
+    assert _resolve(domain="gchat") == gchat_only
+
+
+def test_missing_domain_does_not_borrow_another_domains_model(gchat_only):
+    """The bug: email used to resolve to the gchat checkpoint."""
+    assert _resolve(domain="email") != gchat_only
+
+
+def test_domainless_lookup_still_uses_first_available(gchat_only):
+    """Single-model deployments must keep working."""
+    assert _resolve(domain=None) == gchat_only
+
+
+def test_refusal_is_logged(gchat_only, caplog):
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        _resolve(domain="email")
+    assert any(
+        "refusing to fall back" in r.message.lower()
+        or "refusing to fall back" in str(r.args).lower()
+        for r in caplog.records
+    ), f"expected a refusal warning, got: {[r.message for r in caplog.records]}"
+
+
+def test_explicit_checkpoint_still_honoured(tmp_path, monkeypatch):
+    """A single LEARNED_SCORER_CHECKPOINT is domain-agnostic by construction."""
+    ckpt = tmp_path / "single.pt"
+    ckpt.write_bytes(b"not-a-real-checkpoint")
+    monkeypatch.delenv("LEARNED_SCORER_REGISTRY", raising=False)
+    monkeypatch.setenv("LEARNED_SCORER_CHECKPOINT", str(ckpt))
+    assert _resolve(domain="email") == str(ckpt)
+
+
+def test_checkpoint_domain_mismatch_warns(tmp_path, monkeypatch, caplog):
+    """A correctly-resolved path can still hold the wrong model."""
+    import logging
+
+    torch = pytest.importorskip("torch")
+
+    ckpt_path = tmp_path / "mislabelled.pt"
+    torch.save(
+        {
+            "model_state_dict": {},
+            "model_type": "similarity_mw",
+            "domain_id": "gchat",
+            "input_dim": 9,
+        },
+        ckpt_path,
+    )
+    monkeypatch.delenv("LEARNED_SCORER_REGISTRY", raising=False)
+    monkeypatch.setenv("LEARNED_SCORER_CHECKPOINT", str(ckpt_path))
+
+    from adapters.module_wrapper.search_mixin._learned_model import _load_learned_model
+
+    class _Loader:
+        _learned_model = None
+        _learned_feature_version = None
+        _learned_model_domain = None
+        _learned_model_type = None
+        _resolve_checkpoint_path = _resolve_checkpoint_path
+
+    with caplog.at_level(logging.WARNING):
+        _load_learned_model.__func__(_Loader, domain="email")
+
+    assert any("domain" in r.message.lower() for r in caplog.records), (
+        f"expected a domain-mismatch warning, got: {[r.message for r in caplog.records]}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1165,7 +1165,7 @@ wheels = [
 
 [[package]]
 name = "google-workspace-unlimited"
-version = "2.4.0"
+version = "2.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiodebug" },


### PR DESCRIPTION
## The bug

`MODEL_ARTIFACT_URI` mapped both domains to a `best_model_unified.pt`:

```json
{"gchat": "gs://…/trm/gchat/best_model_unified.pt",
 "email": "gs://…/trm/email/best_model_unified.pt"}
```

The file published under the **email** prefix was a byte-identical copy of the gchat model — same md5, and its own metadata said `domain_id='gchat'`. So anything resolving the `email` domain loaded a gchat-trained scorer, carrying gchat's pool vocabulary and component mapping.

No genuine email `UnifiedTRN` has ever existed. Every `unified_trn` checkpoint in the bucket and in local training output is `domain_id='gchat'`. The email prefix does hold a real `best_model_email.pt`, but it is an older architecture (`model_type='similarity_mw'`, no `domain_id`, no pools) and is not a drop-in.

## Why fixing the config alone wasn't enough

`_resolve_checkpoint_path` ended **both** its cloud-artifact and registry lookups with a "first available" loop:

```python
# Try first available
for d, path in artifact_paths.items():
    if os.path.exists(path):
        return path
```

That returns any checkpoint regardless of the domain requested. Remove the bad `email` entry and an email lookup falls straight through to the gchat model anyway. The config was the symptom; this loop was the bug.

## The fix

1. **The fallback now applies only when no domain was requested.** Single-model deployments (`domain=None`, or a single `LEARNED_SCORER_CHECKPOINT`) keep working exactly as before. An explicit domain with no matching artifact logs a warning and resolves to no model, degrading to heuristics.

2. **The loader cross-checks the checkpoint's own `domain_id`** against the requested domain and warns on mismatch. Resolution can hand back the right *path* and still be the wrong *model* if an artifact was published under the wrong prefix — that is exactly what happened here, and nothing would have caught it.

A model ranking with the wrong pool vocabulary fails silently and confidently. That's the same failure mode that hid the `research/` import regression for ~3 months (#48), so this one gets a loud warning and a guard test rather than a quiet fallback.

## Tests

`tests/module/test_checkpoint_domain_resolution.py` — 6 tests covering exact match, refusal to borrow across domains, the preserved domain-less fallback, the explicit-checkpoint path, and the `domain_id` mismatch warning.

**Three of the six fail against the previous code**, verified by reverting the fix and re-running:

```
FAILED test_missing_domain_does_not_borrow_another_domains_model
FAILED test_refusal_is_logged
FAILED test_checkpoint_domain_mismatch_warns
```

```
508 passed, 32 skipped
ruff check . — All checks passed
ruff format --check . — 514 files already formatted
```

## Operator note

⚠️ **Drop any domain from `MODEL_ARTIFACT_URI` that has no model of its own.** Unmapped domains now degrade to heuristics instead of silently loading a foreign checkpoint. The `email` entry has been removed from the deployment config and the mislabelled artifact deleted from the bucket (archived first, under `trm/archive/2026-04-13/`).

The `settings.py` field description now spells this out, since there is no tracked `.env.example` entry for it.

## Release

`pyproject.toml` and `uv.lock` bumped 2.4.0 → **2.4.1**. Patch — no API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)