### PR TITLE
Release 2.5.0 — Code Mode on by default + README overhaul

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -200,10 +200,12 @@ QDRANT_AUTO_LAUNCH=true
 # CODE MODE (FastMCP 3.1.0+)
 # ============================================
 
-# Enable CodeMode transform for BM25-powered tool discovery
-# When true, LLMs see 4 meta-tools (get_tags, search, get_schema, execute)
-# instead of all 146+ tool schemas loaded upfront
-ENABLE_CODE_MODE=false
+# CodeMode is ON by default: instead of loading 90+ tool schemas upfront,
+# LLMs see 7 meta-tools (tags, search, get_schema, semantic_search,
+# fetch_document, tool_activity, execute) and chain real tool calls inside
+# a sandboxed `execute` Python block.
+# Set to false to expose the classic full tool catalog instead.
+ENABLE_CODE_MODE=true
 
 # ============================================
 # SKILLS PROVIDER

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,11 @@ jobs:
         run: uv run python scripts/lint_no_dag_bypass.py
 
       - name: Check tool description quality
+        # HF_HUB_OFFLINE keeps the server import from spawning background
+        # model downloads that outlive this step and corrupt the HF cache
+        # for later steps; the lint only reads tool descriptions.
+        env:
+          HF_HUB_OFFLINE: "1"
         run: uv run python scripts/lint_tool_descriptions.py
 
       - name: Run unit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Check for DAG-bypass patterns (advisory)
         run: uv run python scripts/lint_no_dag_bypass.py
 
+      - name: Check tool description quality
+        run: uv run python scripts/lint_tool_descriptions.py
+
       - name: Run unit tests
         shell: bash {0}
         run: |

--- a/README.md
+++ b/README.md
@@ -239,6 +239,33 @@ Each connection gets its own **isolated session** with only the requested servic
 
 > See [URL-Based Service Filtering](#-url-based-service-filtering-http-transport) for the full list of query parameters.
 
+### 🤖 Claude Code & Claude Desktop
+
+**Claude Code (CLI)** — one command, using the published PyPI package:
+
+```bash
+# Local stdio (recommended): uvx fetches and runs the server on demand
+claude mcp add google-workspace -- uvx google-workspace-unlimited
+
+# Or connect to an already-running HTTP server
+claude mcp add --transport http google-workspace https://localhost:8002/mcp
+```
+
+**Claude Desktop (local dev path)** — add to `claude_desktop_config.json` (Settings → Developer → Edit Config):
+
+```json
+{
+  "mcpServers": {
+    "google-workspace-unlimited": {
+      "command": "uvx",
+      "args": ["google-workspace-unlimited"]
+    }
+  }
+}
+```
+
+**Claude.ai / Claude Desktop (hosted connector)** — run the server behind a public HTTPS endpoint (e.g. a Cloudflare or ngrok tunnel), then add it under **Settings → Connectors → Add custom connector** with your `https://your-domain/mcp` URL. The server's OAuth 2.1 + PKCE flow handles authentication, including the `https://claude.ai/api/mcp/auth_callback` redirect. See the [Claude.ai Integration Guide](documentation/config/claude_ai_integration_guide.md) for the full walkthrough.
+
 ### 📚 Complete Connection Guide
 
 For detailed setup instructions, troubleshooting, and configurations for all supported clients including:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![pypi](https://img.shields.io/pypi/v/google-workspace-unlimited?color=blue)](https://pypi.org/project/google-workspace-unlimited/)
 [![license](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/dipseth/google_workspace_fastmcp2/blob/main/LICENSE)
 
+[![google_workspace_fastmcp2 MCP server](https://glama.ai/mcp/servers/dipseth/google_workspace_fastmcp2/badges/card.svg)](https://glama.ai/mcp/servers/dipseth/google_workspace_fastmcp2)
+
 **GoogleUnlimited** is a comprehensive MCP framework that provides seamless Google Workspace integration through an advanced middleware architecture. It enables AI assistants and MCP clients to interact with Gmail, Google Drive, Docs, Sheets, Slides, Calendar, Forms, Chat, and Photos services using a unified, secure API.
 
 **What sets it apart:**

--- a/README.md
+++ b/README.md
@@ -6,9 +6,18 @@
 
 **GoogleUnlimited** is a comprehensive MCP framework that provides seamless Google Workspace integration through an advanced middleware architecture. It enables AI assistants and MCP clients to interact with Gmail, Google Drive, Docs, Sheets, Slides, Calendar, Forms, Chat, and Photos services using a unified, secure API.
 
+**What sets it apart:**
+
+- ⚡ **Code Mode by default** — instead of flooding your client with 90+ tool schemas, the server exposes 7 lightweight meta-tools; the AI discovers tools on demand and chains real API calls inside a single sandboxed `execute` block
+- 🚀 **Zero-config startup** — the server runs immediately with no `.env` file; OAuth happens lazily on first use
+- 🔧 **Per-session tool control** — URL-based service filtering and session-scoped enable/disable, so each connected client sees exactly the tools it needs
+- 🎨 **Template & card DSL system** — Jinja2 macros and a compact card notation turn raw API data into rich emails, dashboards, and Google Chat cards
+- 🧠 **Semantic memory** — every tool response is embedded into Qdrant, searchable later with natural language
+
 ## 📋 Table of Contents
 
 - [Quick Installation Instructions](#-quick-installation-instructions)
+- [Code Mode (Default)](#-code-mode-default)
 - [Service Capabilities](#-service-capabilities)
 - [Middleware Architecture](#-middleware-architecture)
 - [Tool Management Dashboard](#️-tool-management-dashboard)
@@ -44,7 +53,7 @@ The fastest way to get started - install directly from PyPI:
 }
 ```
 
-> ⚡ **That's it!** The server runs in stdio mode by default, perfect for MCP clients like Claude Desktop, Cursor, Roo, etc.
+> ⚡ **That's it!** The server runs in stdio mode by default, perfect for MCP clients like Claude Desktop, Cursor, Roo, etc. [Code Mode](#-code-mode-default) is on out of the box, so your client sees 7 lean meta-tools instead of 90+ schemas.
 
 #### Method 2: Clone and Development Setup
 
@@ -133,7 +142,7 @@ All environment variables are **optional** — the server starts with sensible d
 |----------|---------|-------------|
 | `MINIMAL_TOOLS_STARTUP` | `true` | Start with only 5 protected tools enabled |
 | `MINIMAL_STARTUP_SERVICES` | _(empty)_ | Comma-separated services to enable at startup (e.g., `drive,gmail`) |
-| `ENABLE_CODE_MODE` | `false` | Enable CodeMode transform — replaces full tool catalog with BM25 search + sandboxed `execute` |
+| `ENABLE_CODE_MODE` | `true` | Code Mode (default) — replaces the full tool catalog with 7 meta-tools + sandboxed `execute`; set `false` for the classic catalog |
 | `ENABLE_SKILLS_PROVIDER` | `false` | Enable FastMCP SkillsDirectoryProvider for dynamic skill generation |
 | `SKILLS_DIRECTORY` | `~/.claude/skills` | Directory for generated skill documents |
 | `RESPONSE_LIMIT_MAX_SIZE` | `500000` | Max tool response size in bytes (0 = disabled) |
@@ -240,6 +249,46 @@ For detailed setup instructions, troubleshooting, and configurations for all sup
 - And more...
 
 > 🔗 **[Complete Client Connection Guide](documentation/config/MCP_CLIENT_CONNECTIONS.md)** - Comprehensive setup instructions, troubleshooting, and advanced configurations for all supported AI clients and development environments
+
+## ⚡ Code Mode (Default)
+
+Code Mode is GoogleUnlimited's flagship feature — and it's **on by default**. Instead of loading 90+ tool schemas upfront (expensive on tokens), your MCP client sees just **7 meta-tools**. The AI discovers tools on demand, then chains any number of real API calls inside a single sandboxed Python `execute` block.
+
+| Meta-Tool | Purpose |
+|-----------|---------|
+| `tags` | Browse tools by service category (Gmail, Drive, Calendar, etc.) |
+| `search` | BM25-powered keyword search across tool names and descriptions |
+| `get_schema` | Get full parameter schemas for selected tools |
+| `semantic_search` | Natural-language search over previously stored tool responses (Qdrant-backed) |
+| `fetch_document` | Retrieve a full stored response by point ID from search results |
+| `tool_activity` | Summarize recent tool usage patterns and activity |
+| `execute` | Run a sandboxed Python block that chains real tool calls via `await call_tool(name, params)` |
+
+**Why it matters:**
+
+- 💰 **Massive token savings** — 7 schemas instead of 90+, with full schemas fetched only for the tools actually used
+- 🔗 **One round-trip instead of many** — search → filter → act happens inside a single `execute` block, not a chain of client round-trips
+- 🧰 **Batteries-included sandbox** — 40+ built-in helpers (`now()`, `days_ago()`, `to_json()`, `re_find()`, `gather_tools()`, …) cover dates, JSON, URLs, regex, math, and batch calls without any imports
+
+```python
+# One execute block: find a Drive file, then email its link
+files = await call_tool("search_drive_files", {"query": "Q4 report"})
+link = files["files"][0]["webViewLink"]
+result = await call_tool("send_gmail_message", {
+    "to": "manager@company.com",
+    "subject": "Q4 Report",
+    "body": "Here's the Q4 report: " + link,
+})
+return result
+```
+
+**Prefer the classic catalog?** Opt out and every tool is exposed directly to the client:
+
+```bash
+ENABLE_CODE_MODE=false   # expose the full 90+ tool catalog instead
+```
+
+> Code Mode and the classic catalog are mutually exclusive — when Code Mode is active, direct tool calls are replaced by the search + `execute` pattern. Discovery tools always see the full catalog, regardless of session-level filtering.
 
 ## 🎯 Service Capabilities
 
@@ -373,32 +422,6 @@ manage_tools(action="disable", tool_names=["send_gmail_message"], scope="global"
   "message": "Kept 5 tools, disabled 89 tools for this session"
 }
 ```
-
-### 🧠 CodeMode Transform (Experimental)
-
-When enabled via `ENABLE_CODE_MODE=true`, CodeMode replaces the full 92+ tool catalog with **4 meta-tools**, dramatically reducing token usage for LLM clients:
-
-| Meta-Tool | Purpose |
-|-----------|---------|
-| `get_tags` | Browse tools by service category (Gmail, Drive, Calendar, etc.) |
-| `search` | BM25-powered keyword search across tool names and descriptions |
-| `get_schema` | Get full parameter schemas for selected tools |
-| `execute` | Run tool calls in a sandboxed Python block via `await call_tool(name, params)` |
-
-**How it works:** Instead of loading all 92+ tool schemas upfront (expensive on tokens), LLMs discover tools on-demand via search, then chain multiple `call_tool()` calls in a single `execute` block:
-
-```python
-# Single execute block can chain multiple tool calls
-result = await call_tool("search_drive_files", {"query": "Q4 report"})
-return result
-```
-
-**Configuration:**
-```bash
-ENABLE_CODE_MODE=true   # Enable CodeMode transform
-```
-
-> CodeMode and the standard tool catalog are mutually exclusive — when CodeMode is active, direct tool calls are replaced by the search + execute pattern.
 
 ### 📚 Skills Provider
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -325,11 +325,12 @@ class Settings(BaseSettings):
     )
 
     # Code Mode Configuration
-    # When enabled, replaces the full tool catalog with BM25 search + sandboxed execution
+    # Enabled by default: replaces the full tool catalog with BM25 search + sandboxed execution
     # LLMs discover tools via search instead of loading all schemas upfront
+    # Set ENABLE_CODE_MODE=false to expose the classic full tool catalog instead
     enable_code_mode: bool = Field(
-        default=False,
-        description="Enable CodeMode transform for BM25 tool discovery",
+        default=True,
+        description="Enable CodeMode transform for BM25 tool discovery (default). Set false for the classic full tool catalog.",
         json_schema_extra={"env": "ENABLE_CODE_MODE"},
     )
 

--- a/docs/docs_tools.py
+++ b/docs/docs_tools.py
@@ -30,11 +30,12 @@ Dependencies:
 import asyncio
 import io
 import re
-from typing import List, Optional, Union, cast
+from typing import Annotated, List, Optional, Union, cast
 
 from fastmcp import FastMCP
 from googleapiclient.errors import HttpError
 from googleapiclient.http import MediaIoBaseDownload, MediaIoBaseUpload
+from pydantic import Field
 
 from auth.service_helpers import get_injected_service, get_service, request_service
 from config.enhanced_logging import setup_logger
@@ -1363,17 +1364,46 @@ def setup_docs_tools(mcp: FastMCP):
     """
 
     @mcp.tool(
-        name="search_docs", description="Search for Google Docs by name using Drive API"
+        name="search_docs",
+        description=(
+            "Find Google Docs whose NAME contains the query (Drive name-contains match, Docs mime type only).\n"
+            "Use when: locating a Doc by title. For full-text/content search or non-Doc file types, use search_drive_files; to read a found Doc, pass its id to get_doc_content.\n"
+            "Behavior: read-only; excludes trashed files.\n"
+            "Returns: matching docs with id, name, modified time, and webViewLink. Errors: auth failure (run start_google_auth) or Drive permission denial."
+        ),
+        tags={"docs", "search", "google"},
+        annotations={
+            "title": "Search Google Docs by Name",
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "idempotentHint": True,
+            "openWorldHint": True,
+        },
     )
     async def search_docs_tool(
-        query: str, page_size: int = 10, user_google_email: UserGoogleEmail = None
+        query: Annotated[
+            str,
+            Field(
+                description="Substring matched against document names (not content); case-insensitive Drive 'name contains' semantics"
+            ),
+        ],
+        page_size: Annotated[
+            int,
+            Field(description="Maximum documents to return (1-100)", ge=1, le=100),
+        ] = 10,
+        user_google_email: UserGoogleEmail = None,
     ) -> SearchDocsResponse:
         """Search for Google Docs by name."""
         return await search_docs(query, page_size, user_google_email)
 
     @mcp.tool(
         name="get_doc_content",
-        description="Get content of a Google Doc or Drive file (like .docx)",
+        description=(
+            "Read the text content of a native Google Doc (Docs API) or a Word file stored in Drive (.docx download + text extraction).\n"
+            "Use when: reading Docs or .docx documents. For other Drive file types (sheets, PDFs, images, plain text), use get_drive_file_content; to find the document id first, use search_docs.\n"
+            "Behavior: read-only; Office files are downloaded and parsed, which is slower than native Docs.\n"
+            "Returns: extracted text plus title, mime type, and webViewLink. Errors: file not found / no access for bad ids; auth failure (run start_google_auth)."
+        ),
         tags={"docs", "content", "read", "google"},
         annotations={
             "title": "Get Google Doc Content",
@@ -1384,14 +1414,25 @@ def setup_docs_tools(mcp: FastMCP):
         },
     )
     async def get_doc_content_tool(
-        document_id: str, user_google_email: UserGoogleEmail = None
+        document_id: Annotated[
+            str,
+            Field(
+                description="Drive file ID of the Google Doc or Office file (from search_docs, list_docs_in_folder, or a Docs URL)"
+            ),
+        ],
+        user_google_email: UserGoogleEmail = None,
     ) -> GetDocContentResponse:
         """Get content of a Google Doc or Drive file."""
         return await get_doc_content(document_id, user_google_email)
 
     @mcp.tool(
         name="list_docs_in_folder",
-        description="List Google Docs within a specific Drive folder",
+        description=(
+            "List the Google Docs (Docs mime type only) directly inside one Drive folder.\n"
+            "Use when: browsing a known folder's documents. To find Docs by name across Drive, use search_docs; to list all file types in a folder, use list_drive_items.\n"
+            "Behavior: read-only; not recursive — subfolder contents are not included.\n"
+            "Returns: docs with id, name, modified time, and webViewLink. Errors: unknown folder_id or no access; auth failure (run start_google_auth)."
+        ),
         tags={"docs", "list", "folder", "google"},
         annotations={
             "title": "List Google Docs in Folder",
@@ -1402,8 +1443,16 @@ def setup_docs_tools(mcp: FastMCP):
         },
     )
     async def list_docs_in_folder_tool(
-        folder_id: str = "root",
-        page_size: int = 100,
+        folder_id: Annotated[
+            str,
+            Field(
+                description="Drive folder ID to list; 'root' targets My Drive's top level"
+            ),
+        ] = "root",
+        page_size: Annotated[
+            int,
+            Field(description="Maximum documents to return (1-1000)", ge=1, le=1000),
+        ] = 100,
         user_google_email: UserGoogleEmail = None,
     ) -> DocsListResponse:
         """List Google Docs within a specific folder."""

--- a/drive/drive_tools.py
+++ b/drive/drive_tools.py
@@ -575,7 +575,12 @@ def setup_drive_comprehensive_tools(mcp: FastMCP) -> None:
     # Register the search_drive_files tool (module-level function)
     mcp.tool(
         name="search_drive_files",
-        description="Search Google Drive files with easy file type filtering. Use mime_type parameter for simple filtering (PDF, GOOGLE_DOCS, EXCEL, etc.) or query parameter for advanced Google Drive Query Language searches.",
+        description=(
+            "Search all of Google Drive: name/content queries via Drive Query Language plus simple mime_type filters (PDF, GOOGLE_DOCS, EXCEL, ...).\n"
+            "Use when: searching across file types or by content. To find Google Docs by title only, search_docs is simpler; to read a hit, pass its id to get_drive_file_content.\n"
+            "Behavior: read-only; supports shared drives.\n"
+            "Returns: files with id, name, mime type, size, and links. Errors: malformed query strings are rejected by the Drive API; auth failure (run start_google_auth)."
+        ),
         tags={
             "drive",
             "search",
@@ -597,7 +602,12 @@ def setup_drive_comprehensive_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(
         name="get_drive_file_content",
-        description="Retrieve the content of a Google Drive file by ID, supporting multiple formats",
+        description=(
+            "Read any Drive file's content as text: native Docs/Sheets/Slides are exported (text/CSV), Office files are parsed, other types are UTF-8 decoded or flagged as binary.\n"
+            "Use when: reading arbitrary Drive files by id. For Google Docs/.docx specifically, get_doc_content returns structured metadata; find ids first with search_drive_files.\n"
+            "Behavior: read-only; supports shared drives.\n"
+            "Returns: plain text with a metadata header (name, mime type, link). Errors: file not found / no access; binary formats yield a notation instead of content."
+        ),
         tags={"drive", "file", "content", "download", "read"},
         annotations={
             "title": "Get Drive File Content",

--- a/gchat/card_tools.py
+++ b/gchat/card_tools.py
@@ -533,12 +533,12 @@ def setup_card_tools(mcp: FastMCP) -> None:
     gitem_sym = symbols.get("GridItem", "ǵ")
 
     tool_description = (
-        "Send cards to Google Chat using DSL notation for precise structure control. "
-        "REQUIRED: Use DSL symbols in card_description to define card structure. "
-        f"Common patterns: {section_sym}[{dtext_sym}] = text card, "
-        f"{section_sym}[{dtext_sym}, {btnlist_sym}[{btn_sym}×2]] = text + 2 buttons, "
-        f"{section_sym}[{grid_sym}[{gitem_sym}×4]] = grid with 4 items. "
-        f"{dsl_field_desc}"
+        "Send a rich interactive card (text, buttons, grids, images) to Google Chat, structured with DSL symbols in card_description.\n"
+        "Use when: content needs layout or interactivity. For plain text messages, use send_message instead.\n"
+        f"Canonical example: {section_sym}[{dtext_sym}, {btnlist_sym}[{btn_sym}×2]] = one section with text and 2 buttons. "
+        "The full symbol table and worked examples live in this tool's annotations (dsl_documentation, examples) and the card_description parameter help — don't guess symbols.\n"
+        "Behavior: posts immediately via webhook (default) or Chat API (space_id); not idempotent — repeated calls post duplicate cards. Without DSL symbols the card degrades to plain text. draft_variations=true sends 3 design drafts to a shared thread instead of the original card.\n"
+        "Returns: delivery result with card type, thread key, and validation status. Errors: invalid DSL fails validation before anything is sent; webhook or Chat-API auth failures are reported per delivery method."
     )
 
     # Build dynamic field help - DSL is primary, NL is fallback

--- a/gchat/chat_tools.py
+++ b/gchat/chat_tools.py
@@ -812,7 +812,12 @@ def setup_chat_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(
         name="send_message",
-        description="Sends a message to a Google Chat space with full markdown formatting support",
+        description=(
+            "Post a plain-text message (Google Chat markdown supported) to a Chat space, optionally threaded via thread_key.\n"
+            "Use when: sending text. For interactive cards, buttons, or rich layouts, use send_dynamic_card; for space administration, use manage_space.\n"
+            "Behavior: posts immediately to the space; not idempotent — repeated calls post duplicates. Chat markdown differs from standard: *bold*, _italic_, ~strike~, <url|text> links.\n"
+            "Returns: the created message name and thread info. Errors: unknown space_id, or the service account/user lacks access to the space."
+        ),
         tags={"chat", "message", "send", "google", "markdown", "formatting"},
         annotations={
             "title": "Send Chat Message",
@@ -1079,12 +1084,17 @@ def setup_chat_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(
         name="manage_space",
-        description="Unified tool for Google Chat space administration: manage members, create/update/delete spaces",
+        description=(
+            "Administer a Google Chat space: members (list/add/remove), space lifecycle (create/update/delete), messages (get/update/delete), and reactions.\n"
+            "Use when: changing a space or its membership. To post content, use send_message (text) or send_dynamic_card (cards); to read history, use list_messages.\n"
+            "Behavior: DESTRUCTIVE for delete_space (removes the space and all its messages), delete_message, and remove_member — these are immediate and irreversible. Reaction actions require delegated user auth.\n"
+            "Returns: per-action result with the affected resource name. Errors: missing required params for the chosen action; 403 when the authenticated user lacks space-manager rights."
+        ),
         tags={"chat", "spaces", "members", "management"},
         annotations={
             "title": "Manage Chat Space",
             "readOnlyHint": False,
-            "destructiveHint": False,
+            "destructiveHint": True,
             "idempotentHint": False,
             "openWorldHint": True,
         },

--- a/gmail/compose.py
+++ b/gmail/compose.py
@@ -3758,10 +3758,12 @@ def setup_compose_tools(mcp: FastMCP) -> None:
     )
 
     compose_tool_description = (
-        "Compose responsive HTML emails using DSL notation for block structure. "
-        f"Common patterns: {spec_sym}[{hero_sym}, {text_sym}] = hero + text, "
-        f"{spec_sym}[{hero_sym}, {text_sym}x2, {btn_sym}] = hero + 2 text blocks + button. "
-        f"{email_dsl_field_desc}"
+        "Compose a responsive HTML (MJML) email from DSL block notation, then save it as a Gmail draft or send it.\n"
+        "Use when: the email needs styled layout (hero, buttons, sections). For plain-text or simple HTML mail, use send_gmail_message instead.\n"
+        f"Canonical example: {spec_sym}[{hero_sym}, {text_sym}] = hero + text block. "
+        "The full symbol table and worked examples live in this tool's annotations (dsl_documentation, examples) and the email_description parameter help — don't guess symbols.\n"
+        "Behavior: action='draft' (default) only creates a draft; action='send' delivers immediately to to/cc/bcc with no confirmation step. Not idempotent — repeated sends deliver duplicates.\n"
+        "Returns: message/draft id and delivery status. Errors: missing DSL notation in email_description fails before any send; invalid recipients or Gmail auth failures are reported per attempt."
     )
 
     email_description_help = (

--- a/middleware/server_middleware_setup.py
+++ b/middleware/server_middleware_setup.py
@@ -70,7 +70,10 @@ def setup_all_middleware(
 
         setup_code_mode(mcp)
     else:
-        logger.info("Code Mode disabled — set ENABLE_CODE_MODE=true in .env to enable")
+        logger.info(
+            "Code Mode disabled — serving the classic full tool catalog "
+            "(unset ENABLE_CODE_MODE or set it to true to restore the default)"
+        )
 
     # ─── 3. Auth Middleware ───
     from auth.context import set_auth_middleware

--- a/photos/advanced_tools.py
+++ b/photos/advanced_tools.py
@@ -132,7 +132,12 @@ def setup_advanced_photos_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(
         name="photos_smart_search",
-        description="Advanced photo search with smart filtering and optimization",
+        description=(
+            "Search the user's entire Google Photos library by content category (PEOPLE, ANIMALS, FOOD, ...) and/or date range, with photo/video type toggles.\n"
+            "Use when: filtering the whole library. To search within one album, use search_photos with album_id; to list an album's full contents, use list_album_photos.\n"
+            "Behavior: read-only; API responses are cached per user, so repeated identical searches may return cached results.\n"
+            "Returns: matched media items with metadata plus timing/cache stats. Errors: invalid date format (dates must be YYYY-MM-DD) or missing Photos auth (run start_google_auth)."
+        ),
         tags={"photos", "search", "advanced", "optimized", "google"},
         annotations={
             "title": "Smart Photo Search",
@@ -623,7 +628,12 @@ def setup_advanced_photos_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(
         name="photos_optimized_album_sync",
-        description="Efficiently sync and analyze album contents with smart caching",
+        description=(
+            "Fetch one album's contents and summarize its metadata: photo/video counts, years covered, cameras, and file types.\n"
+            "Use when: you need an album overview or statistics. For the raw item list, use list_album_photos; for filtered searches, use search_photos.\n"
+            "Behavior: read-only; processes at most max_items (default 200) — larger albums are truncated without warning; per-user response cache may serve repeated calls.\n"
+            "Returns: analysis counts plus cache-hit statistics. Errors: unknown album_id, or missing Photos auth."
+        ),
         tags={"photos", "album", "sync", "optimized", "google"},
         annotations={
             "title": "Optimized Album Sync",
@@ -793,7 +803,12 @@ def setup_advanced_photos_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(
         name="upload_photos",
-        description="Upload one or more photos to Google Photos with batch optimization",
+        description=(
+            "Upload one local photo (string path) or a batch (list of paths) to Google Photos, optionally adding them to an existing album (album_id) or a newly created one (create_album).\n"
+            "Use when: uploading specific files. To upload a whole directory, use upload_folder_photos instead.\n"
+            "Behavior: writes to the user's library; batch items are independent — some can succeed while others fail, and partial success is NOT reported as an error. If create_album fails, uploads continue without an album.\n"
+            "Returns: successful[] and failed[] lists with per-file detail plus totals. Errors: per-file entries in failed[] (missing path, unsupported format, quota); auth failures fail the whole call."
+        ),
         tags={"photos", "upload", "batch", "single", "google"},
         annotations={
             "title": "Upload Photos",
@@ -1035,7 +1050,12 @@ def setup_advanced_photos_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(
         name="upload_folder_photos",
-        description="Upload all photos from a folder (with optional recursion) to Google Photos",
+        description=(
+            "Scan a local folder (recursive by default) for image files and upload them all to Google Photos.\n"
+            "Use when: uploading a directory wholesale. For an explicit list of files, use upload_photos instead.\n"
+            "Behavior: writes to the user's library; files upload independently with partial-failure semantics (some succeed, some fail, no rollback). create_album works; album_id is currently NOT applied — photos land unorganized if only album_id is given.\n"
+            "Returns: per-file results with success/failure counts and any created album id. Errors: nonexistent folder path; per-file failures listed individually."
+        ),
         tags={"photos", "upload", "folder", "batch", "recursive", "google"},
         annotations={
             "title": "Upload Folder Photos",

--- a/photos/photos_tools.py
+++ b/photos/photos_tools.py
@@ -221,7 +221,12 @@ def setup_photos_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(
         name="search_photos",
-        description="Search for photos in Google Photos using filters",
+        description=(
+            "Search Google Photos by content category and/or date range, optionally scoped to one album via album_id.\n"
+            "Use when: filtering photos inside a specific album, or simple library filters. To list an entire album unfiltered, use list_album_photos; for library-wide search with photo/video toggles and cached performance, use photos_smart_search.\n"
+            "Behavior: read-only.\n"
+            "Returns: matching photos with metadata and URLs (max_results caps output, default 25). Errors: invalid YYYY-MM-DD dates, unknown album_id, or missing Photos auth."
+        ),
         tags={"photos", "search", "filter", "google"},
         annotations={
             "title": "Search Google Photos",
@@ -382,7 +387,12 @@ def setup_photos_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(
         name="list_album_photos",
-        description="List all photos from a specific album",
+        description=(
+            "List every photo in one Google Photos album, unfiltered.\n"
+            "Use when: you have an album_id and want its full contents. To filter within an album, use search_photos with album_id; for library-wide search, use photos_smart_search.\n"
+            "Behavior: read-only.\n"
+            "Returns: photos with metadata and URLs, capped at max_results (default 50). Errors: unknown album_id or missing Photos auth."
+        ),
         tags={"photos", "album", "list", "google"},
         annotations={
             "title": "List Album Photos",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "google-workspace-unlimited"
-version = "2.4.1"
-description = "Comprehensive MCP server for Google Workspace integration - 72+ tools across Gmail, Drive, Docs, Sheets, Slides, Calendar, Forms, Chat, and Photos with OAuth 2.1 + PKCE authentication"
+version = "2.5.0"
+description = "Comprehensive MCP server for Google Workspace integration - 90+ tools across Gmail, Drive, Docs, Sheets, Slides, Calendar, Forms, Chat, and Photos with Code Mode tool discovery and OAuth 2.1 + PKCE authentication"
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.11,<3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,7 +200,7 @@ known-third-party = ["card_framework", "google", "googleapiclient", "google_auth
 known-first-party = ["auth", "config", "drive", "gmail", "photos", "middleware", "gcalendar", "gchat", "docs", "forms", "sheets", "slides", "resources", "prompts", "people", "adapters", "tools", "skills", "lifespans"]
 
 [tool.hatch.build.targets.wheel]
-packages = ["auth", "config", "drive", "gmail", "photos", "middleware", "gcalendar", "gchat", "docs", "forms", "sheets", "slides", "resources", "prompts", "people", "adapters", "tools"]
+packages = ["auth", "config", "drive", "gmail", "photos", "middleware", "gcalendar", "gchat", "docs", "forms", "sheets", "slides", "resources", "prompts", "people", "adapters", "tools", "lifespans", "skills"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "server.py" = "server.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "google-workspace-unlimited"
-version = "2.5.0"
+version = "2.5.1"
 description = "Comprehensive MCP server for Google Workspace integration - 90+ tools across Gmail, Drive, Docs, Sheets, Slides, Calendar, Forms, Chat, and Photos with Code Mode tool discovery and OAuth 2.1 + PKCE authentication"
 readme = "README.md"
 license = "Apache-2.0"

--- a/scripts/lint_tool_descriptions.py
+++ b/scripts/lint_tool_descriptions.py
@@ -22,6 +22,7 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import sys
 from pathlib import Path
@@ -175,4 +176,10 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    rc = main()
+    sys.stdout.flush()
+    sys.stderr.flush()
+    # Hard-exit to skip interpreter teardown: importing `server` loads C++
+    # extensions (qdrant-client, tokenizers) that abort with SIGABRT (exit
+    # 134) during normal shutdown, which would fail CI after a passing lint.
+    os._exit(rc)

--- a/scripts/lint_tool_descriptions.py
+++ b/scripts/lint_tool_descriptions.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Lint check for MCP tool description quality.
+
+Enforces the Glama-audit remediation playbook on a maintained list of tools:
+every enforced description must carry a "Use when:" routing line, stay under
+a length cap, and avoid marketing adjectives in place of mechanics. Tools not
+yet on the enforced list produce warnings only, so coverage can grow without
+breaking CI.
+
+Checks both the full tool catalog (what ``get_schema``/``execute`` expose)
+and the seven Code Mode meta-tools (what Glama introspects as of 2.5.0).
+
+Usage:
+    python scripts/lint_tool_descriptions.py
+    python scripts/lint_tool_descriptions.py --verbose
+
+Exit codes:
+    0 - No violations found
+    1 - Violations found
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+# Tools whose descriptions follow the playbook and must not regress.
+# Add tools here as their descriptions get the playbook treatment.
+ENFORCED_TOOLS: set[str] = {
+    # Code Mode meta-tools (the front door since 2.5.0)
+    "execute",
+    "search",
+    "tags",
+    "get_schema",
+    "semantic_search",
+    "fetch_document",
+    "tool_activity",
+    # Photos
+    "photos_smart_search",
+    "photos_optimized_album_sync",
+    "upload_photos",
+    "upload_folder_photos",
+    "search_photos",
+    "list_album_photos",
+    # Docs
+    "search_docs",
+    "get_doc_content",
+    "list_docs_in_folder",
+    # Drive
+    "search_drive_files",
+    "get_drive_file_content",
+    # Chat
+    "manage_space",
+    "send_message",
+    "send_dynamic_card",
+    # Gmail
+    "compose_dynamic_email",
+    # System
+    "manage_credentials",
+    "health_check",
+}
+
+# Adjectives the audit flagged as replacing mechanics with marketing.
+BANNED_ADJECTIVES = re.compile(
+    r"\b(smart|optimized|advanced|powerful)\b", re.IGNORECASE
+)
+
+# Description length cap (characters). Tools exempted below legitimately
+# carry reference material (sandbox helper list, dynamic DSL symbol table).
+MAX_DESCRIPTION_CHARS = 1500
+LENGTH_EXEMPT: set[str] = {"execute", "semantic_search"}
+
+
+def _collect_tools() -> dict[str, str]:
+    """Return {tool_name: description} for catalog tools + meta-tools."""
+    from fastmcp.tools import Tool
+
+    import server
+    from tools.code_mode import EXECUTE_DESCRIPTION, get_discovery_tool_factories
+
+    descriptions: dict[str, str] = {}
+
+    for component in server.mcp.local_provider._components.values():
+        if isinstance(component, Tool):
+            descriptions[component.name] = component.description or ""
+
+    async def _stub_catalog(ctx=None, **kwargs):
+        return []
+
+    for factory in get_discovery_tool_factories():
+        tool = factory(_stub_catalog)
+        descriptions[tool.name] = tool.description or ""
+    descriptions["execute"] = EXECUTE_DESCRIPTION
+
+    return descriptions
+
+
+def check_description(name: str, desc: str, all_names: set[str]) -> list[str]:
+    """Return a list of violation messages for one enforced tool."""
+    problems: list[str] = []
+
+    if not desc.strip():
+        return [f"{name}: description is empty"]
+
+    if "Use when:" not in desc:
+        problems.append(f"{name}: missing 'Use when:' routing line")
+
+    # Strip tool-name mentions (e.g. photos_smart_search) before the
+    # adjective check so routing references don't trigger it.
+    stripped = desc
+    for other in all_names:
+        stripped = stripped.replace(other, "")
+    match = BANNED_ADJECTIVES.search(stripped)
+    if match:
+        problems.append(
+            f"{name}: marketing adjective '{match.group(0)}' — state mechanics instead"
+        )
+
+    if name not in LENGTH_EXEMPT and len(desc) > MAX_DESCRIPTION_CHARS:
+        problems.append(
+            f"{name}: description is {len(desc)} chars (cap {MAX_DESCRIPTION_CHARS})"
+        )
+
+    return problems
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args()
+
+    descriptions = _collect_tools()
+    all_names = set(descriptions.keys())
+
+    missing = ENFORCED_TOOLS - all_names
+    violations: list[str] = [
+        f"{name}: enforced tool not found in catalog" for name in sorted(missing)
+    ]
+
+    for name in sorted(ENFORCED_TOOLS & all_names):
+        violations.extend(check_description(name, descriptions[name], all_names))
+
+    warnings = [
+        name
+        for name in sorted(all_names - ENFORCED_TOOLS)
+        if "Use when:" not in descriptions[name]
+    ]
+
+    if args.verbose:
+        for name in sorted(ENFORCED_TOOLS & all_names):
+            print(f"  ✓ checked {name} ({len(descriptions[name])} chars)")
+
+    if warnings:
+        print(
+            f"⚠ {len(warnings)} non-enforced tools lack a 'Use when:' line "
+            "(advisory — add them to ENFORCED_TOOLS as they get the playbook treatment)"
+        )
+        if args.verbose:
+            for name in warnings:
+                print(f"    - {name}")
+
+    if violations:
+        print(f"\n✗ {len(violations)} tool description violation(s):")
+        for violation in violations:
+            print(f"  - {violation}")
+        return 1
+
+    print(f"✓ {len(ENFORCED_TOOLS & all_names)} enforced tool descriptions pass")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/data/tool_schema_snapshot.json
+++ b/tests/data/tool_schema_snapshot.json
@@ -1,0 +1,672 @@
+{
+  "add_questions_to_form": [
+    "form_id",
+    "questions",
+    "user_google_email"
+  ],
+  "add_slide": [
+    "index",
+    "layout_id",
+    "presentation_id",
+    "user_google_email"
+  ],
+  "bulk_calendar_operations": [
+    "attendee_email",
+    "calendar_id",
+    "dry_run",
+    "location_pattern",
+    "max_results",
+    "operation",
+    "time_max",
+    "time_min",
+    "title_pattern",
+    "user_google_email"
+  ],
+  "check_drive_auth": [
+    "cross_oauth_password",
+    "user_google_email"
+  ],
+  "cleanup_qdrant_data": [
+    "user_google_email"
+  ],
+  "compose_dynamic_email": [
+    "action",
+    "bcc",
+    "cc",
+    "email_description",
+    "email_params",
+    "to",
+    "user_google_email"
+  ],
+  "create_calendar": [
+    "description",
+    "location",
+    "summary",
+    "time_zone",
+    "user_google_email"
+  ],
+  "create_doc": [
+    "content",
+    "content_mime_type",
+    "document_id",
+    "edit_config",
+    "title",
+    "user_google_email"
+  ],
+  "create_drive_file": [
+    "content",
+    "fileUrl",
+    "file_name",
+    "folder_id",
+    "mime_type",
+    "user_google_email"
+  ],
+  "create_event": [
+    "attachments",
+    "attendees",
+    "calendar_id",
+    "description",
+    "duration",
+    "end_time",
+    "events",
+    "location",
+    "recurrence",
+    "start_time",
+    "summary",
+    "timezone",
+    "user_google_email"
+  ],
+  "create_form": [
+    "description",
+    "document_title",
+    "title",
+    "user_google_email"
+  ],
+  "create_gmail_filter": [
+    "add_label_ids",
+    "exclude_chats",
+    "forward_to",
+    "from_address",
+    "has_attachment",
+    "mark_as_important",
+    "mark_as_spam",
+    "never_mark_as_important",
+    "never_mark_as_spam",
+    "query",
+    "remove_label_ids",
+    "size",
+    "size_comparison",
+    "subject_contains",
+    "to_address",
+    "user_google_email"
+  ],
+  "create_photos_album": [
+    "title",
+    "user_google_email"
+  ],
+  "create_presentation": [
+    "title",
+    "user_google_email"
+  ],
+  "create_sheet": [
+    "sheet_name",
+    "spreadsheet_id",
+    "user_google_email"
+  ],
+  "create_spreadsheet": [
+    "sheet_names",
+    "title",
+    "user_google_email"
+  ],
+  "create_template_macro": [
+    "description",
+    "macro_content",
+    "macro_name",
+    "persist_to_file",
+    "usage_example",
+    "user_google_email"
+  ],
+  "delete_event": [
+    "calendar_id",
+    "event_id",
+    "user_google_email"
+  ],
+  "delete_gmail_filter": [
+    "filter_id",
+    "user_google_email"
+  ],
+  "download_gmail_attachment": [
+    "filename",
+    "message_id",
+    "return_content",
+    "return_url",
+    "save_dir",
+    "user_google_email"
+  ],
+  "draft_gmail_forward": [
+    "bcc",
+    "body",
+    "cc",
+    "content_type",
+    "html_body",
+    "message_id",
+    "to",
+    "user_google_email"
+  ],
+  "draft_gmail_message": [
+    "bcc",
+    "body",
+    "cc",
+    "content_type",
+    "email_spec",
+    "html_body",
+    "subject",
+    "to",
+    "user_google_email"
+  ],
+  "draft_gmail_reply": [
+    "bcc",
+    "body",
+    "cc",
+    "content_type",
+    "html_body",
+    "message_id",
+    "reply_mode",
+    "to",
+    "user_google_email"
+  ],
+  "export_and_download_presentation": [
+    "download_directory",
+    "download_to_local",
+    "export_format",
+    "presentation_id",
+    "user_google_email"
+  ],
+  "fetch": [
+    "order_by",
+    "order_direction",
+    "point_id",
+    "point_ids",
+    "user_google_email"
+  ],
+  "format_sheet_range": [
+    "apply_borders",
+    "background_color",
+    "bold",
+    "border_color",
+    "border_positions",
+    "border_style",
+    "bottom_border",
+    "cell_format",
+    "column_width",
+    "condition_format_background_color",
+    "condition_format_bold",
+    "condition_format_italic",
+    "condition_format_text_color",
+    "condition_type",
+    "condition_value",
+    "conditional_rules",
+    "font_size",
+    "freeze_columns",
+    "freeze_rows",
+    "horizontal_alignment",
+    "inner_horizontal_border",
+    "inner_vertical_border",
+    "italic",
+    "left_border",
+    "merge_cells_option",
+    "number_format_pattern",
+    "number_format_type",
+    "range_end_col",
+    "range_end_row",
+    "range_start_col",
+    "range_start_row",
+    "right_border",
+    "row_height",
+    "sheet_id",
+    "spreadsheet_id",
+    "text_color",
+    "text_rotation",
+    "top_border",
+    "user_google_email",
+    "vertical_alignment",
+    "wrap_strategy"
+  ],
+  "forward_gmail_message": [
+    "bcc",
+    "body",
+    "cc",
+    "content_type",
+    "html_body",
+    "message_id",
+    "to",
+    "user_google_email"
+  ],
+  "get_doc_content": [
+    "document_id",
+    "user_google_email"
+  ],
+  "get_drive_file_content": [
+    "file_id",
+    "user_google_email"
+  ],
+  "get_event": [
+    "calendar_id",
+    "event_id",
+    "user_google_email"
+  ],
+  "get_form": [
+    "form_id",
+    "user_google_email"
+  ],
+  "get_form_response": [
+    "form_id",
+    "response_id",
+    "user_google_email"
+  ],
+  "get_gmail_filter": [
+    "filter_id",
+    "user_google_email"
+  ],
+  "get_gmail_message_content": [
+    "message_id",
+    "user_google_email"
+  ],
+  "get_gmail_messages_content_batch": [
+    "format",
+    "message_ids",
+    "user_google_email"
+  ],
+  "get_gmail_thread_content": [
+    "thread_id",
+    "user_google_email"
+  ],
+  "get_people_contact_group_members": [
+    "label",
+    "user_google_email"
+  ],
+  "get_photo_details": [
+    "media_item_id",
+    "user_google_email"
+  ],
+  "get_photos_library_info": [
+    "user_google_email"
+  ],
+  "get_presentation_info": [
+    "presentation_id",
+    "user_google_email"
+  ],
+  "get_response_details": [
+    "point_id",
+    "user_google_email"
+  ],
+  "get_spreadsheet_info": [
+    "spreadsheet_id",
+    "user_google_email"
+  ],
+  "get_tool_analytics": [
+    "end_date",
+    "group_by",
+    "start_date",
+    "summary_only",
+    "user_google_email"
+  ],
+  "health_check": [
+    "user_google_email"
+  ],
+  "list_album_photos": [
+    "album_id",
+    "max_results",
+    "user_google_email"
+  ],
+  "list_calendars": [
+    "user_google_email"
+  ],
+  "list_docs_in_folder": [
+    "folder_id",
+    "page_size",
+    "user_google_email"
+  ],
+  "list_drive_items": [
+    "folder_id",
+    "include_files",
+    "include_subfolders",
+    "page_size",
+    "user_google_email"
+  ],
+  "list_events": [
+    "calendar_id",
+    "max_results",
+    "time_max",
+    "time_min",
+    "user_google_email"
+  ],
+  "list_form_responses": [
+    "form_id",
+    "page_size",
+    "page_token",
+    "user_google_email"
+  ],
+  "list_gmail_filters": [
+    "user_google_email"
+  ],
+  "list_gmail_labels": [
+    "user_google_email"
+  ],
+  "list_messages": [
+    "order_by",
+    "page_size",
+    "space_id",
+    "user_google_email"
+  ],
+  "list_people_contact_labels": [
+    "user_google_email"
+  ],
+  "list_photos_albums": [
+    "exclude_non_app_created",
+    "max_results",
+    "user_google_email"
+  ],
+  "list_spaces": [
+    "page_size",
+    "space_type",
+    "user_google_email"
+  ],
+  "list_spreadsheets": [
+    "max_results",
+    "user_google_email"
+  ],
+  "make_drive_files_public": [
+    "file_ids",
+    "public",
+    "role",
+    "user_google_email"
+  ],
+  "manage_credentials": [
+    "action",
+    "email",
+    "new_storage_mode"
+  ],
+  "manage_drive_files": [
+    "file_ids",
+    "name_prefix",
+    "new_name",
+    "operation",
+    "permanent",
+    "remove_from_all_parents",
+    "target_folder_id",
+    "user_google_email"
+  ],
+  "manage_gmail_allow_list": [
+    "action",
+    "email",
+    "label",
+    "user_google_email"
+  ],
+  "manage_gmail_label": [
+    "action",
+    "background_color",
+    "label_id",
+    "label_list_visibility",
+    "message_list_visibility",
+    "name",
+    "text_color",
+    "user_google_email"
+  ],
+  "manage_people_contact_labels": [
+    "action",
+    "email",
+    "label",
+    "user_google_email"
+  ],
+  "manage_space": [
+    "action",
+    "description",
+    "display_name",
+    "emoji",
+    "member_email",
+    "member_name",
+    "member_role",
+    "message_name",
+    "message_text",
+    "reaction_name",
+    "space_id",
+    "space_type",
+    "user_google_email"
+  ],
+  "manage_tools": [
+    "action",
+    "include_internal",
+    "scope",
+    "service_filter",
+    "tool_names",
+    "user_google_email"
+  ],
+  "modify_event": [
+    "attendees",
+    "calendar_id",
+    "description",
+    "duration",
+    "end_time",
+    "event_id",
+    "location",
+    "recurrence",
+    "start_time",
+    "summary",
+    "timezone",
+    "user_google_email"
+  ],
+  "modify_gmail_message_labels": [
+    "add_label_ids",
+    "message_id",
+    "remove_label_ids",
+    "user_google_email"
+  ],
+  "modify_sheet_values": [
+    "clear_values",
+    "range_name",
+    "spreadsheet_id",
+    "user_google_email",
+    "value_input_option",
+    "values"
+  ],
+  "move_events_between_calendars": [
+    "delete_from_source",
+    "max_results",
+    "source_calendar_id",
+    "target_calendar_id",
+    "time_max",
+    "time_min",
+    "title_pattern",
+    "user_google_email"
+  ],
+  "photos_batch_details": [
+    "media_item_ids",
+    "user_google_email"
+  ],
+  "photos_optimized_album_sync": [
+    "album_id",
+    "analyze_metadata",
+    "max_items",
+    "user_google_email"
+  ],
+  "photos_performance_stats": [
+    "clear_cache",
+    "user_google_email"
+  ],
+  "photos_smart_search": [
+    "content_categories",
+    "date_end",
+    "date_start",
+    "include_photos",
+    "include_videos",
+    "max_results",
+    "user_google_email"
+  ],
+  "publish_form_publicly": [
+    "anyone_can_respond",
+    "form_id",
+    "share_with_emails",
+    "user_google_email"
+  ],
+  "qdrant_search": [
+    "collection",
+    "dry_run",
+    "filter_dsl",
+    "limit",
+    "negative_point_ids",
+    "positive_point_ids",
+    "prefetch_dsl",
+    "query",
+    "query_dsl",
+    "score_threshold",
+    "user_google_email"
+  ],
+  "read_sheet_values": [
+    "date_time_render_option",
+    "range_name",
+    "spreadsheet_id",
+    "user_google_email",
+    "value_render_option"
+  ],
+  "reply_to_gmail_message": [
+    "bcc",
+    "body",
+    "cc",
+    "content_type",
+    "html_body",
+    "message_id",
+    "reply_mode",
+    "to",
+    "user_google_email"
+  ],
+  "search_docs": [
+    "page_size",
+    "query",
+    "user_google_email"
+  ],
+  "search_drive_files": [
+    "corpora",
+    "drive_id",
+    "include_items_from_all_drives",
+    "mime_type",
+    "page_size",
+    "query",
+    "user_google_email"
+  ],
+  "search_gmail_messages": [
+    "page_size",
+    "query",
+    "user_google_email"
+  ],
+  "search_messages": [
+    "page_size",
+    "query",
+    "space_id",
+    "user_google_email"
+  ],
+  "search_photos": [
+    "album_id",
+    "content_categories",
+    "date_end",
+    "date_start",
+    "max_results",
+    "user_google_email"
+  ],
+  "search_tool_history": [
+    "limit",
+    "query",
+    "tool_name",
+    "user_email",
+    "user_google_email"
+  ],
+  "send_dynamic_card": [
+    "card_description",
+    "card_params",
+    "draft_variations",
+    "space_id",
+    "thread_key",
+    "user_google_email",
+    "webhook_url"
+  ],
+  "send_gmail_message": [
+    "bcc",
+    "body",
+    "cc",
+    "content_type",
+    "email_spec",
+    "html_body",
+    "subject",
+    "to",
+    "user_google_email"
+  ],
+  "send_message": [
+    "message_text",
+    "space_id",
+    "thread_key",
+    "user_google_email"
+  ],
+  "set_form_publish_state": [
+    "accepting_responses",
+    "form_id",
+    "user_google_email"
+  ],
+  "set_privacy_mode": [
+    "additional_fields",
+    "mask_content",
+    "mode",
+    "user_google_email"
+  ],
+  "share_drive_files": [
+    "email_addresses",
+    "file_ids",
+    "message",
+    "role",
+    "send_notification",
+    "user_google_email"
+  ],
+  "start_google_auth": [
+    "auth_method",
+    "auto_open_browser",
+    "cross_oauth_password",
+    "service_name",
+    "show_service_selection",
+    "user_google_email"
+  ],
+  "update_form_questions": [
+    "form_id",
+    "questions_to_update",
+    "user_google_email"
+  ],
+  "update_slide_content": [
+    "presentation_id",
+    "requests",
+    "user_google_email"
+  ],
+  "upload_folder_photos": [
+    "album_id",
+    "create_album",
+    "folder_path",
+    "recursive",
+    "user_google_email"
+  ],
+  "upload_photos": [
+    "album_id",
+    "create_album",
+    "description",
+    "file_paths",
+    "user_google_email"
+  ],
+  "upload_to_drive": [
+    "filename",
+    "folder_id",
+    "path",
+    "user_google_email"
+  ],
+  "verify_payment": [
+    "chain_id",
+    "payment_payload_b64",
+    "tx_hash",
+    "user_google_email"
+  ]
+}

--- a/tests/test_tool_schemas.py
+++ b/tests/test_tool_schemas.py
@@ -1,0 +1,70 @@
+"""Snapshot test for tool parameter schemas.
+
+Guards against parameters silently dropping out of generated JSON schemas
+(the ``get_doc_content`` class of bug from the Glama audit): every tool's
+parameter names are snapshotted to ``tests/data/tool_schema_snapshot.json``.
+
+On an intentional schema change, regenerate the snapshot:
+
+    UPDATE_TOOL_SCHEMA_SNAPSHOT=1 uv run pytest tests/test_tool_schemas.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+SNAPSHOT_PATH = Path(__file__).parent / "data" / "tool_schema_snapshot.json"
+
+
+def _current_schemas() -> dict[str, list[str]]:
+    from fastmcp.tools import Tool
+
+    import server
+
+    schemas: dict[str, list[str]] = {}
+    for component in server.mcp.local_provider._components.values():
+        if isinstance(component, Tool):
+            properties = (component.parameters or {}).get("properties", {})
+            schemas[component.name] = sorted(properties.keys())
+    return schemas
+
+
+def test_tool_parameter_schemas_match_snapshot():
+    current = _current_schemas()
+    assert current, "no tools found on server.mcp.local_provider"
+
+    if (
+        os.environ.get("UPDATE_TOOL_SCHEMA_SNAPSHOT") == "1"
+        or not SNAPSHOT_PATH.exists()
+    ):
+        SNAPSHOT_PATH.parent.mkdir(parents=True, exist_ok=True)
+        SNAPSHOT_PATH.write_text(json.dumps(current, indent=2, sort_keys=True) + "\n")
+        if os.environ.get("UPDATE_TOOL_SCHEMA_SNAPSHOT") == "1":
+            return  # explicit regeneration
+
+    snapshot: dict[str, list[str]] = json.loads(SNAPSHOT_PATH.read_text())
+
+    removed_tools = sorted(set(snapshot) - set(current))
+    changed = {
+        name: {
+            "missing_params": sorted(set(params) - set(current[name])),
+            "new_params": sorted(set(current[name]) - set(params)),
+        }
+        for name, params in snapshot.items()
+        if name in current and sorted(params) != current[name]
+    }
+
+    problems = []
+    if removed_tools:
+        problems.append(f"tools removed since snapshot: {removed_tools}")
+    for name, diff in changed.items():
+        problems.append(f"{name}: {diff}")
+
+    assert not problems, (
+        "Tool schemas diverged from snapshot (parameters may have silently "
+        "dropped out). If intentional, regenerate with "
+        "UPDATE_TOOL_SCHEMA_SNAPSHOT=1 uv run pytest tests/test_tool_schemas.py\n"
+        + "\n".join(problems)
+    )

--- a/tools/code_mode.py
+++ b/tools/code_mode.py
@@ -283,9 +283,11 @@ class EnhancedSandboxProvider(MontySandboxProvider):
 
 # Description shown to LLMs for the execute tool — documents every available helper.
 EXECUTE_DESCRIPTION = (
-    "Chain `await call_tool(...)` calls in one Python block; prefer returning the final answer from a single block.\n"
-    "Use `return` to produce output.\n"
-    "Only `call_tool(tool_name: str, params: dict) -> Any` is available in scope.\n"
+    "Run sandboxed Python that calls this server's Google Workspace tools via `await call_tool(tool_name, params)`, chaining calls in one block.\n"
+    "Use when: you know which tools to call. To find tool names first use `search` or `tags`; for exact parameters use `get_schema`; to look up past results instead, use `semantic_search`.\n"
+    "Behavior: each call_tool runs the real tool immediately — sends, edits, and deletes take effect; there is no dry-run.\n"
+    "Use `return` to produce output; prefer returning the final answer from a single block.\n"
+    "Only `call_tool(tool_name: str, params: dict) -> Any` is available in scope. Unknown tool names raise NotFoundError; disallowed syntax raises SandboxError.\n"
     "\n"
     "**SANDBOX RESTRICTIONS — these produce SandboxError, avoid them:**\n"
     "- `[*a, *b]` → use `a + b` instead\n"
@@ -423,7 +425,7 @@ def _get_qdrant_dsl_reference() -> str:
 
         lines = ["DSL filter symbols: " + ", ".join(filter_syms)]
         if query_syms:
-            lines.append("Advanced query symbols: " + ", ".join(query_syms))
+            lines.append("Query-DSL symbols: " + ", ".join(query_syms))
 
         # Build dynamic examples from actual symbols
         f_sym = symbols.get("Filter", "")
@@ -475,7 +477,7 @@ class SemanticSearch:
             ] = None,
             query_dsl: Annotated[
                 str | None,
-                "Advanced query DSL for recommend, discover, fusion, or order-by queries",
+                "Query DSL for recommend, discover, fusion, or order-by queries",
             ] = None,
             prefetch_dsl: Annotated[
                 str | None,
@@ -572,16 +574,19 @@ class SemanticSearch:
         # Dynamic docstring — symbols generated from wrapper, never hardcoded
         dsl_ref = _get_qdrant_dsl_reference()
         semantic_search.__doc__ = (
-            "Search the Qdrant vector database.\n\n"
-            "Supports multiple search modes:\n"
-            "- Semantic: natural language query matched by embedding similarity\n"
-            "- Service history: 'service:gmail last week', 'tool:search recent'\n"
-            "- Analytics: 'overview', 'dashboard', 'usage stats'\n"
-            "- DSL filter: filter_dsl for precise structured filtering\n"
-            "- Recommendation: find similar via positive/negative point IDs\n"
-            "- Advanced: query_dsl for fusion, discover, order-by queries\n"
-            "- Multi-stage: prefetch_dsl for hierarchical retrieval\n\n"
-            "Returns point IDs usable with fetch_document for content preview.\n"
+            "Search the Qdrant vector store of this server's past tool responses and card templates.\n\n"
+            "Use when: looking up previous results, usage history, or analytics "
+            "('service:gmail last week', 'tool:search recent', 'overview'). "
+            "For discovering tools to call, use search; to preview one stored document, "
+            "pass its point ID to fetch_document.\n\n"
+            "Modes: semantic text similarity; service/tool history queries; analytics "
+            "('overview', 'usage stats'); filter_dsl for structured filters; "
+            "positive/negative point IDs for recommendation; query_dsl for "
+            "fusion/discover/order-by; prefetch_dsl for multi-stage retrieval.\n\n"
+            "Behavior: read-only against the local Qdrant instance; no Google APIs are called.\n"
+            "Returns: scored rows 'score service/tool timestamp id:<point_id>'.\n"
+            "Errors: 'Search failed' when Qdrant is unreachable; 'No results' when nothing "
+            "clears score_threshold (default 0.3 — lower it to widen the net).\n"
             + (f"\n{dsl_ref}" if dsl_ref else "")
         )
 
@@ -616,11 +621,16 @@ class FetchDocument:
             user_google_email: UserGoogleEmail = None,
             ctx: Context = None,  # type: ignore[assignment]
         ) -> str:
-            """Peek at a stored response by point ID.
+            """Preview one stored tool response by its Qdrant point ID.
 
-            Returns tool name, service, timestamp, arguments, and a
-            truncated content preview. For full content, use fetch in
-            an execute block.
+            Use when: inspecting a hit returned by semantic_search. To find
+            point IDs in the first place, use semantic_search; for the full
+            untruncated content, call the `fetch` tool inside an execute block.
+
+            Behavior: read-only.
+            Returns: tool name, service, timestamp, user, argument count, and
+            the first 500 characters of stored content.
+            Errors: 'Document not found' for unknown or expired point IDs.
             """
             params: dict[str, Any] = {"point_id": point_id}
             if user_google_email:
@@ -687,10 +697,16 @@ class ToolActivity:
             user_google_email: UserGoogleEmail = None,
             ctx: Context = None,  # type: ignore[assignment]
         ) -> str:
-            """Show a dashboard of tool usage activity.
+            """Show usage analytics for this server's tools: call counts, error rates, last-used times.
 
-            Returns which tools have been called, how often, error rates,
-            and sample point IDs for deeper inspection via fetch_document.
+            Use when: answering 'what has been used or failing lately'. To read
+            an individual response, pass a sample point ID to fetch_document;
+            to discover tools to call, use search instead.
+
+            Behavior: read-only aggregation over the Qdrant response store.
+            Returns: a text dashboard grouped by tool_name or user_email, with
+            sample point IDs per group.
+            Errors: 'Analytics failed' when the response store is unreachable.
             """
             params: dict[str, Any] = {"summary_only": True, "group_by": group_by}
             if user_google_email:
@@ -759,6 +775,70 @@ class ToolActivity:
 # ---------------------------------------------------------------------------
 
 
+class _DescribedFactory:
+    """Wrap a discovery-tool factory to override the built Tool's description.
+
+    The upstream factories (``GetTags``, ``Search``, ``GetSchemas``) take their
+    descriptions from inner-function docstrings with no override hook, so we
+    patch the ``Tool`` after construction.
+    """
+
+    def __init__(self, factory: Any, description: str) -> None:
+        self._factory = factory
+        self._description = description
+
+    def __call__(self, get_catalog: GetToolCatalog) -> Tool:
+        tool = self._factory(get_catalog)
+        try:
+            tool.description = self._description
+        except (AttributeError, TypeError, ValueError):
+            tool = tool.model_copy(update={"description": self._description})
+        return tool
+
+
+TAGS_DESCRIPTION = (
+    "List this server's tool tags (service areas like gmail, drive, docs, photos) with tool counts.\n"
+    "Use when: browsing what capability areas exist before a targeted lookup. "
+    "For keyword lookup use search; for parameters of known tools use get_schema.\n"
+    "Returns: '- tag (N tools)' lines at detail='brief' (default), or every tool listed under each tag at detail='full'."
+)
+
+SEARCH_DESCRIPTION = (
+    "Find this server's Google Workspace tools by keyword (BM25 over names, descriptions, and tags).\n"
+    "Use when: you don't know the exact tool name yet. To browse by category use tags; "
+    "once you have names, use get_schema for parameters, then execute to call them. "
+    "To search past results rather than tools, use semantic_search.\n"
+    "Returns: matching tools as names + descriptions ('brief', default), parameter markdown "
+    "('detailed'), or complete JSON definitions ('full'). An empty result means no keyword "
+    "match — retry with different terms."
+)
+
+GET_SCHEMA_DESCRIPTION = (
+    "Get parameter schemas for named tools before calling them via execute.\n"
+    "Use when: you already have tool names (from search or tags) and need exact parameters. "
+    "Not for discovery — use search for that.\n"
+    "Returns: per-tool parameter markdown ('detailed', default), names + descriptions "
+    "('brief'), or full JSON schemas ('full'); unknown names are reported under "
+    "'Tools not found'."
+)
+
+
+def get_discovery_tool_factories() -> list[Any]:
+    """Return the discovery-tool factories used by Code Mode.
+
+    Shared by ``setup_code_mode`` and ``scripts/lint_tool_descriptions.py``
+    so the lint checks the exact tools the server registers.
+    """
+    return [
+        _DescribedFactory(GetTags(), TAGS_DESCRIPTION),
+        _DescribedFactory(Search(default_limit=10), SEARCH_DESCRIPTION),
+        _DescribedFactory(GetSchemas(), GET_SCHEMA_DESCRIPTION),
+        SemanticSearch(),
+        FetchDocument(),
+        ToolActivity(),
+    ]
+
+
 def setup_code_mode(mcp: FastMCP) -> None:
     """Register the CodeMode transform on *mcp*.
 
@@ -772,14 +852,7 @@ def setup_code_mode(mcp: FastMCP) -> None:
     """
     code_mode = CodeMode(
         sandbox_provider=EnhancedSandboxProvider(),
-        discovery_tools=[
-            GetTags(),
-            Search(default_limit=10),
-            GetSchemas(),
-            SemanticSearch(),
-            FetchDocument(),
-            ToolActivity(),
-        ],
+        discovery_tools=get_discovery_tool_factories(),
         execute_description=EXECUTE_DESCRIPTION,
     )
 

--- a/tools/server_tools.py
+++ b/tools/server_tools.py
@@ -586,7 +586,12 @@ def setup_server_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(
         name="health_check",
-        description="Check server health and configuration",
+        description=(
+            "Report this MCP server's runtime status: OAuth configuration and migration state, active credential sessions, and enabled feature flags.\n"
+            "Use when: diagnosing auth problems or confirming server configuration. For a specific user's credential storage details, use manage_credentials with action='status'; to verify Drive access works end-to-end, use check_drive_auth.\n"
+            "Behavior: read-only; touches no Google APIs.\n"
+            "Returns: structured health status (oauth status, session counts, configuration summary). Errors: none expected — degraded subsystems are reported in the response body."
+        ),
         tags={"server", "health", "monitoring", "status", "system"},
         annotations={
             "title": "Server Health Check",
@@ -618,7 +623,12 @@ def setup_server_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(
         name="manage_credentials",
-        description="Manage credential storage and security settings",
+        description=(
+            "Inspect or change how one user's Google OAuth credentials are stored: 'status' and 'summary' report state, 'migrate' moves between storage modes (FILE_PLAINTEXT, FILE_ENCRYPTED, MEMORY_ONLY, MEMORY_WITH_BACKUP), 'delete' removes stored credentials.\n"
+            "Use when: auditing or changing credential storage. For overall server health, use health_check; to (re)authenticate a user, use start_google_auth.\n"
+            "Behavior: DESTRUCTIVE for action='delete' — the user's stored credentials are permanently removed with no undo, and they must re-run start_google_auth. 'migrate' rewrites credentials into the new mode; MEMORY_ONLY modes do not survive a server restart.\n"
+            "Returns: structured result with the action outcome and current storage mode. Errors: no credentials found for the email; invalid new_storage_mode when action='migrate'."
+        ),
         tags={"credentials", "security", "migration", "management", "storage"},
         annotations={
             "title": "Credential Management",

--- a/uv.lock
+++ b/uv.lock
@@ -1165,7 +1165,7 @@ wheels = [
 
 [[package]]
 name = "google-workspace-unlimited"
-version = "2.4.1"
+version = "2.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiodebug" },


### PR DESCRIPTION
## Summary

- **Code Mode is now the default** (`ENABLE_CODE_MODE=true`): clients get the 7 meta-tool surface — `tags`, `search`, `get_schema`, `semantic_search`, `fetch_document`, `tool_activity`, `execute` — instead of 90+ schemas loaded upfront. Set `ENABLE_CODE_MODE=false` to restore the classic full catalog.
- **README overhaul**: Code Mode promoted to its own top-level section (the old subsection was buried under middleware, marked experimental, and listed only 4 of the 7 meta-tools), a new "What sets it apart" highlights list in the intro, and the env-var table/`.env.example` updated for the new default.
- **Version bumped 2.4.1 → 2.5.0** — merging this to `main` triggers the PyPI publish workflow (version-change gate), tagging, and GitHub release.

## Notes

- Client tests already detect the Code Mode surface and adapt (`tests/client/test_mcp_client.py`).
- `uv run pytest tests/test_code_mode.py`: 102 passed; the 3 failures (starred-collection sandbox errors) are pre-existing on `main` and unrelated.
- `ruff check .` and `ruff format --check .` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)