### PR TITLE
chore: bump FastMCP 3.4.4 → 3.4.6

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -290,3 +290,15 @@ QDRANT_EMBEDDING_MODEL=sentence-transformers/all-MiniLM-L6-v2
 # BASE_URL=https://your-machine.your-tailnet.ts.net
 # OAUTH_REDIRECT_URI=http://localhost:8002/oauth2callback
 # MCP_REQUIRE_EXISTING_CREDENTIALS=true
+
+# ============================================
+# CORPORATE EGRESS PROXY (FastMCP >= 3.4.6)
+# ============================================
+
+# If this server's OUTBOUND traffic (Google OAuth metadata / JWKS fetches)
+# must go through a corporate HTTP proxy, opt in to FastMCP's trusted-proxy
+# mode. FastMCP then routes its SSRF-protected fetches through the proxy and
+# refuses to fall back to a direct, unprotected request if the proxy is down.
+# Leave BOTH unset for direct-egress deployments (the default).
+# FASTMCP_SSRF_TRUST_PROXY=true
+# HTTPS_PROXY=http://proxy.corp.example:8080

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ classifiers = [
 ]
 dependencies = [
     # Core MCP Framework
-    "fastmcp[anthropic,tasks,code-mode,apps]>=3.4.4",
+    "fastmcp[anthropic,tasks,code-mode,apps]>=3.4.6",
     "litellm>=1.80.0",
     # Google APIs
     "google-api-python-client>=2.168.0",

--- a/uv.lock
+++ b/uv.lock
@@ -907,14 +907,14 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.4.4"
+version = "3.4.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp-slim", extra = ["client", "server"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/f7/5188565d1b93ad611cbd80bf473e7ad669d1f3b689c4bedcd304e1ec3472/fastmcp-3.4.4.tar.gz", hash = "sha256:378202e26ec15b23819d9a1c0d1b0ebda096bc712720532010a0b82a45c2b1df", size = 28796458, upload-time = "2026-07-09T00:32:41.352Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/5a/e2c78e26233cd8a416b21513e1925435d54c008a0ec467dbdaa80369daf7/fastmcp-3.4.6.tar.gz", hash = "sha256:2287938da8364ad7071bec2d2393af6ae10fd4e836f06f506569f1456cc87eb4", size = 28808130, upload-time = "2026-08-05T14:54:42.177Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/67/3cef84ba38a23dca1e1e776bfda8a35ab3c7a6c94a8ca81d0715de6dd3c5/fastmcp-3.4.4-py3-none-any.whl", hash = "sha256:f86f208713212260068cf55c32936839eee856fefc7808e18a032f31eb0f718e", size = 8019, upload-time = "2026-07-09T00:32:39.411Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/a5/c02275db111892388972edbb05fbcbfdf1e83cbd1fd03356b3a49b93f839/fastmcp-3.4.6-py3-none-any.whl", hash = "sha256:2a29967be9f68cdd1b4cefb413ede74f83adefd923919a37aaac3611eccdd749", size = 8017, upload-time = "2026-08-05T14:54:38.473Z" },
 ]
 
 [package.optional-dependencies]
@@ -933,7 +933,7 @@ tasks = [
 
 [[package]]
 name = "fastmcp-slim"
-version = "3.4.4"
+version = "3.4.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "platformdirs" },
@@ -943,9 +943,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/45/79/f35661c6a1d76dfbe17a079f912d96fffcfdd40fad5a9144bb9e7dfb1fdf/fastmcp_slim-3.4.4.tar.gz", hash = "sha256:dcaa3e0be2127d7eacdce592c2ef0039204923dc0ec396454615cb4a3275b078", size = 590203, upload-time = "2026-07-09T00:32:20.531Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/b6/b5b9e81e67a3f39534881d2af6aa3fbd2dc367eaa070c3c932770a0c062f/fastmcp_slim-3.4.6.tar.gz", hash = "sha256:6a1e6e42c697ba90abcb1be617a26947d07316f13c6fa138ae7b0de24558e32c", size = 594167, upload-time = "2026-08-05T14:54:15.924Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/91/321e0b2e9ed70d0628b17ddaec76fc7b09f3e1d5d290f70bf101a2890142/fastmcp_slim-3.4.4-py3-none-any.whl", hash = "sha256:9d3a6327b9ee835188eb7323fc3b5d4cd061631b48da8ece56794bb538972505", size = 765158, upload-time = "2026-07-09T00:32:19.11Z" },
+    { url = "https://files.pythonhosted.org/packages/11/0b/02c254c46b4323ae5262b76a29af73b50a863efc5739a3454d144d3605ee/fastmcp_slim-3.4.6-py3-none-any.whl", hash = "sha256:3e08e6acb03523a47aa17f4d2ab9943e648a41e20b24084da491a732c46dffdc", size = 769174, upload-time = "2026-08-05T14:54:14.663Z" },
 ]
 
 [package.optional-dependencies]
@@ -1228,7 +1228,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=46.0.5" },
     { name = "fastapi", specifier = ">=0.128.0" },
     { name = "fastembed", specifier = ">=0.7.2" },
-    { name = "fastmcp", extras = ["anthropic", "tasks", "code-mode", "apps"], specifier = ">=3.4.4" },
+    { name = "fastmcp", extras = ["anthropic", "tasks", "code-mode", "apps"], specifier = ">=3.4.6" },
     { name = "google-api-python-client", specifier = ">=2.168.0" },
     { name = "google-auth-httplib2", specifier = ">=0.2.0" },
     { name = "google-auth-oauthlib", specifier = ">=1.2.2" },


### PR DESCRIPTION
## Summary

Bumps FastMCP from 3.4.4 → 3.4.6 (constraint now `>=3.4.6`, lockfile re-resolved) and documents the one new opt-in feature relevant to this server.

### What we pick up

**3.4.5**
- **Deterministic required-parameter ordering in transformed tools (#4665)** — the only change that touches a code path we use: `middleware/sampling_middleware.py` builds ctx-injected tools via `Tool.from_tool()`. Transformed tool schemas are now byte-stable across restarts, which helps client-side prompt caching of tool definitions and keeps schema snapshots (Qdrant analytics, evals) comparable across runs.
- `compress_schema` no longer mutates caller schema objects — free hygiene.
- Ed25519 JWKS skip, Azure scope fallback, deep-object query serialization — none apply (Google JWKS is RSA-only; no Azure; no OpenAPI client).

**3.4.6**
- **Trusted SSRF proxy support (#4755)** — opt-in egress-proxy mode for OAuth-metadata/JWKS fetches, enabled via `FASTMCP_SSRF_TRUST_PROXY=true` + `HTTPS_PROXY`. Our deployments egress directly, so nothing is enabled; documented as a commented-out section in `.env.example` for anyone running the server behind a corporate proxy. No behavior change when unset.

### Changes
- `pyproject.toml` — `fastmcp[anthropic,tasks,code-mode,apps]>=3.4.4` → `>=3.4.6`
- `uv.lock` — fastmcp + fastmcp-slim 3.4.4 → 3.4.6 (only these two packages moved)
- `.env.example` — new commented "Corporate egress proxy" section

### Verification
- `ruff check .` and `ruff format --check .` both pass
- Targeted test files run on 3.4.6: `test_sampling_middleware_unit.py`, `test_tool_schemas.py`, `test_oauth_proxy.py`, `test_oauth_config.py`, `test_auth_utils.py`

Two local-environment failures were investigated and confirmed **pre-existing and unrelated to fastmcp** (the affected pipeline — `adapters/module_wrapper/`, email/gchat wrapper setup — imports no fastmcp at all):

1. **Wrapper singleton self-deadlock** (`adapters/module_wrapper/wrapper_factory.py:82`): when Qdrant is reachable but has no instance patterns, the gchat DAG warm-start hook re-enters `WrapperRegistry.get()` for the wrapper currently being created, on the same thread, under a non-reentrant `threading.Lock` → permanent hang. Only reproducible in a fresh checkout pointed at a Qdrant without warm-start state (CI has no Qdrant; prod has populated collections). Worth a follow-up fix — filed in the PR discussion rather than bundled here.
2. **Degraded email symbol table** (`KeyError: 'EmailSpec'` during `import server`): same root cause class — fresh environment + partially-populated local Qdrant yields a 2-entry symbol table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
