### PR TITLE
Release 2.6.0 — Sheets: raw batchUpdate escape hatch, batch/append values, read-back fields + typing/UNMERGE fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "google-workspace-unlimited"
-version = "2.5.2"
+version = "2.6.0"
 description = "Comprehensive MCP server for Google Workspace integration - 90+ tools across Gmail, Drive, Docs, Sheets, Slides, Calendar, Forms, Chat, and Photos with Code Mode tool discovery and OAuth 2.1 + PKCE authentication"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sheets/sheets_tools.py
+++ b/sheets/sheets_tools.py
@@ -21,6 +21,8 @@ from config.enhanced_logging import setup_logger
 from tools.common_types import UserGoogleEmailSheets
 
 from .sheets_types import (
+    BatchModifyValuesResponse,
+    BatchUpdateSheetResponse,
     CreateSheetResponse,
     CreateSpreadsheetResponse,
     FormatRangeResponse,
@@ -117,6 +119,24 @@ def _parse_json_dict(value: Any, field_name: str) -> Optional[dict]:
     raise ValueError(
         f"Invalid type for {field_name}: expected string (JSON) or dict, got {type(value).__name__}"
     )
+
+
+_SCALAR_CELL_TYPES = (str, int, float, bool, type(None))
+
+
+def _validate_2d_values(parsed_values: List[Any]) -> Optional[str]:
+    """
+    Validate a parsed values payload is a 2D array of scalar cells.
+
+    Returns an error message string if invalid, or None if valid.
+    """
+    if not all(
+        isinstance(row, list)
+        and all(isinstance(cell, _SCALAR_CELL_TYPES) for cell in row)
+        for row in parsed_values
+    ):
+        return "Values must be a 2D array of scalar cells (strings, numbers, booleans, or null)."
+    return None
 
 
 async def _get_sheets_service_with_fallback(user_google_email: str):
@@ -335,7 +355,22 @@ def setup_sheets_tools(mcp: FastMCP) -> None:
         },
     )
     async def get_spreadsheet_info(
-        spreadsheet_id: str, user_google_email: UserGoogleEmailSheets = None
+        spreadsheet_id: str,
+        user_google_email: UserGoogleEmailSheets = None,
+        fields: Annotated[
+            Optional[str],
+            Field(
+                default=None,
+                description=(
+                    "Optional Google API field mask to read back detail beyond sheet titles/dimensions — "
+                    "formatting, conditional format rules, charts, merges, data validation, etc. "
+                    'Examples: "sheets(properties,conditionalFormats)", "sheets(properties,charts)", '
+                    '"sheets(properties(title,sheetId),data(rowData(values(userEnteredFormat))))". '
+                    "When provided, the raw API response is returned in the 'raw' field. "
+                    "Warning: grid-data masks can return large payloads; scope them tightly."
+                ),
+            ),
+        ] = None,
     ) -> SpreadsheetDetailsResponse:
         """
         Gets information about a specific spreadsheet including its sheets.
@@ -343,19 +378,24 @@ def setup_sheets_tools(mcp: FastMCP) -> None:
         Args:
             user_google_email (str): The user's Google email address. Required.
             spreadsheet_id (str): The ID of the spreadsheet to get info for. Required.
+            fields (Optional[str]): Google API field mask for detailed read-back (formatting, charts, conditional formats, ...). The raw response is returned in 'raw'.
 
         Returns:
             SpreadsheetDetailsResponse: Structured spreadsheet information including title and sheets list.
         """
         logger.info(
-            f"[get_spreadsheet_info] Invoked. Email: '{user_google_email}', Spreadsheet ID: {spreadsheet_id}"
+            f"[get_spreadsheet_info] Invoked. Email: '{user_google_email}', Spreadsheet ID: {spreadsheet_id}, fields: {fields}"
         )
 
         try:
             sheets_service = await _get_sheets_service_with_fallback(user_google_email)
 
+            request_kwargs: dict = {"spreadsheetId": spreadsheet_id}
+            if fields:
+                request_kwargs["fields"] = fields
+
             spreadsheet = await asyncio.to_thread(
-                sheets_service.spreadsheets().get(spreadsheetId=spreadsheet_id).execute
+                sheets_service.spreadsheets().get(**request_kwargs).execute
             )
 
             title = spreadsheet.get("properties", {}).get("title", "Unknown")
@@ -388,6 +428,7 @@ def setup_sheets_tools(mcp: FastMCP) -> None:
                 sheets=sheets_info,
                 sheetCount=len(sheets),
                 spreadsheetUrl=spreadsheet_url,
+                raw=spreadsheet if fields else None,
             )
 
         except HttpError as e:
@@ -526,8 +567,8 @@ def setup_sheets_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(
         name="modify_sheet_values",
-        description="Modify values in a specific range of a Google Sheet - can write, update, or clear values",
-        tags={"sheets", "write", "update", "clear", "google"},
+        description="Modify values in a specific range of a Google Sheet - can write, update, append, or clear values",
+        tags={"sheets", "write", "update", "append", "clear", "google"},
         annotations={
             "title": "Modify Sheet Values",
             "readOnlyHint": False,
@@ -540,10 +581,10 @@ def setup_sheets_tools(mcp: FastMCP) -> None:
         spreadsheet_id: str,
         range_name: str,
         values: Annotated[
-            Optional[Union[str, List[List[str]]]],
+            Optional[Union[str, List[List[Any]]]],
             Field(
                 default=None,
-                description='2D array of values to write/update. Can be Python list [["cell1", "cell2"], ["cell3", "cell4"]] or JSON string \'[["cell1", "cell2"], ["cell3", "cell4"]]\'. Required unless clear_values=True.',
+                description='2D array of values to write/update. Cells may be strings, numbers, booleans, or null (numbers/booleans are written as real values with RAW input). Can be Python list [["a", 1], ["b", 2.5]] or JSON string. Required unless clear_values=True.',
             ),
         ] = None,
         value_input_option: Annotated[
@@ -560,47 +601,62 @@ def setup_sheets_tools(mcp: FastMCP) -> None:
                 description="If True, clears the range instead of writing values. When True, 'values' parameter is ignored.",
             ),
         ] = False,
+        append: Annotated[
+            bool,
+            Field(
+                default=False,
+                description="If True, appends values as new rows after the last row of data in the table containing range_name, instead of overwriting the range.",
+            ),
+        ] = False,
         user_google_email: UserGoogleEmailSheets = None,
     ) -> SheetModifyResponse:
         """
-        Modifies values in a specific range of a Google Sheet - can write, update, or clear values.
+        Modifies values in a specific range of a Google Sheet - can write, update, append, or clear values.
 
         Args:
             spreadsheet_id (str): The ID of the spreadsheet. Required.
             range_name (str): The range to modify (e.g., "Sheet1!A1:D10", "A1:D10"). Required.
-            values (Optional[Union[str, List[List[str]]]]): 2D array of values to write/update. Can be Python list or JSON string. Required unless clear_values=True.
+            values (Optional[Union[str, List[List[Any]]]]): 2D array of scalar values to write/update. Can be Python list or JSON string. Required unless clear_values=True.
             value_input_option (str): How to interpret input values ("RAW" or "USER_ENTERED"). Defaults to "USER_ENTERED".
             clear_values (bool): If True, clears the range instead of writing values. Defaults to False.
+            append (bool): If True, appends values after the last row of the table containing the range. Defaults to False.
             user_google_email (str): The user's Google email address. Auto-injected by middleware if not provided.
 
         Returns:
             SheetModifyResponse: Structured response with details of the modification operation.
         """
-        operation = "clear" if clear_values else "write"
+        operation = "clear" if clear_values else ("append" if append else "update")
         logger.info(
             f"[modify_sheet_values] Invoked. Operation: {operation}, Email: '{user_google_email}', Spreadsheet: {spreadsheet_id}, Range: {range_name}"
         )
 
         try:
+            if clear_values and append:
+                return SheetModifyResponse(
+                    spreadsheetId=spreadsheet_id,
+                    range=range_name,
+                    operation="error",
+                    success=False,
+                    message="",
+                    error="'clear_values' and 'append' are mutually exclusive.",
+                )
+
             # Parse values parameter to handle JSON strings from MCP clients
             parsed_values = None
             if values is not None:
                 try:
                     parsed_values = _parse_json_list(values, "values")
-                    # Validate that it's a 2D array of strings
-                    if parsed_values and not all(
-                        isinstance(row, list)
-                        and all(isinstance(cell, str) for cell in row)
-                        for row in parsed_values
-                    ):
-                        return SheetModifyResponse(
-                            spreadsheetId=spreadsheet_id,
-                            range=range_name,
-                            operation="error",
-                            success=False,
-                            message="",
-                            error="Values must be a 2D array of strings (List[List[str]]).",
-                        )
+                    if parsed_values:
+                        validation_error = _validate_2d_values(parsed_values)
+                        if validation_error:
+                            return SheetModifyResponse(
+                                spreadsheetId=spreadsheet_id,
+                                range=range_name,
+                                operation="error",
+                                success=False,
+                                message="",
+                                error=validation_error,
+                            )
                 except ValueError as e:
                     return SheetModifyResponse(
                         spreadsheetId=spreadsheet_id,
@@ -644,6 +700,43 @@ def setup_sheets_tools(mcp: FastMCP) -> None:
                     success=True,
                     message=f"Successfully cleared range '{cleared_range}' in spreadsheet {spreadsheet_id}.",
                 )
+            elif append:
+                body = {"values": parsed_values}
+
+                result = await asyncio.to_thread(
+                    sheets_service.spreadsheets()
+                    .values()
+                    .append(
+                        spreadsheetId=spreadsheet_id,
+                        range=range_name,
+                        valueInputOption=value_input_option,
+                        insertDataOption="INSERT_ROWS",
+                        body=body,
+                    )
+                    .execute
+                )
+
+                updates = result.get("updates", {})
+                updated_range = updates.get("updatedRange")
+                updated_cells = updates.get("updatedCells", 0)
+                updated_rows = updates.get("updatedRows", 0)
+                updated_columns = updates.get("updatedColumns", 0)
+
+                logger.info(
+                    f"Successfully appended {updated_rows} rows at '{updated_range}' for {user_google_email}."
+                )
+
+                return SheetModifyResponse(
+                    spreadsheetId=spreadsheet_id,
+                    range=range_name,
+                    operation="append",
+                    updatedRange=updated_range,
+                    updatedCells=updated_cells,
+                    updatedRows=updated_rows,
+                    updatedColumns=updated_columns,
+                    success=True,
+                    message=f"Successfully appended {updated_rows} rows at '{updated_range}' in spreadsheet {spreadsheet_id}.",
+                )
             else:
                 body = {"values": parsed_values}
 
@@ -671,6 +764,7 @@ def setup_sheets_tools(mcp: FastMCP) -> None:
                     spreadsheetId=spreadsheet_id,
                     range=range_name,
                     operation="update",
+                    updatedRange=result.get("updatedRange"),
                     updatedCells=updated_cells,
                     updatedRows=updated_rows,
                     updatedColumns=updated_columns,
@@ -684,7 +778,7 @@ def setup_sheets_tools(mcp: FastMCP) -> None:
             return SheetModifyResponse(
                 spreadsheetId=spreadsheet_id,
                 range=range_name,
-                operation="clear" if clear_values else "update",
+                operation=operation,
                 success=False,
                 message="",
                 error=error_msg,
@@ -695,7 +789,7 @@ def setup_sheets_tools(mcp: FastMCP) -> None:
             return SheetModifyResponse(
                 spreadsheetId=spreadsheet_id,
                 range=range_name,
-                operation="clear" if clear_values else "update",
+                operation=operation,
                 success=False,
                 message="",
                 error=error_msg,
@@ -917,7 +1011,9 @@ def setup_sheets_tools(mcp: FastMCP) -> None:
             "title": "Unified Sheet Range Formatter",
             "readOnlyHint": False,
             "destructiveHint": False,
-            "idempotentHint": True,
+            # Not idempotent: conditional formatting rules are added (not replaced)
+            # on every call, so repeat calls with conditional rules accumulate rules.
+            "idempotentHint": False,
             "openWorldHint": True,
         },
     )
@@ -1265,22 +1361,42 @@ def setup_sheets_tools(mcp: FastMCP) -> None:
                     "positions": final_border_positions,
                 }
 
-            # 3. Merge cells
+            # 3. Merge / unmerge cells
             if merge_cells_option:
-                requests.append(
-                    {
-                        "mergeCells": {
-                            "range": {
-                                "sheetId": sheet_id,
-                                "startRowIndex": range_start_row,
-                                "endRowIndex": range_end_row,
-                                "startColumnIndex": range_start_col,
-                                "endColumnIndex": range_end_col,
-                            },
-                            "mergeType": merge_cells_option,
+                merge_range = {
+                    "sheetId": sheet_id,
+                    "startRowIndex": range_start_row,
+                    "endRowIndex": range_end_row,
+                    "startColumnIndex": range_start_col,
+                    "endColumnIndex": range_end_col,
+                }
+                if merge_cells_option == "UNMERGE":
+                    # The API has no "UNMERGE" mergeType; unmerging is its own request.
+                    requests.append({"unmergeCells": {"range": merge_range}})
+                elif merge_cells_option in (
+                    "MERGE_ALL",
+                    "MERGE_ROWS",
+                    "MERGE_COLUMNS",
+                ):
+                    requests.append(
+                        {
+                            "mergeCells": {
+                                "range": merge_range,
+                                "mergeType": merge_cells_option,
+                            }
                         }
-                    }
-                )
+                    )
+                else:
+                    return FormatRangeResponse(
+                        spreadsheetId=spreadsheet_id,
+                        sheetId=sheet_id,
+                        range="",
+                        requestsApplied=0,
+                        formattingDetails={},
+                        success=False,
+                        message="",
+                        error=f"Invalid merge_cells_option '{merge_cells_option}'. Must be one of: MERGE_ALL, MERGE_ROWS, MERGE_COLUMNS, UNMERGE.",
+                    )
                 formatting_details["merge"] = merge_cells_option
 
             # 4. Column width
@@ -1479,6 +1595,331 @@ def setup_sheets_tools(mcp: FastMCP) -> None:
                 range="",
                 requestsApplied=0,
                 formattingDetails={},
+                success=False,
+                message="",
+                error=error_msg,
+            )
+
+    @mcp.tool(
+        name="batch_update_sheet",
+        description=(
+            "Apply raw Google Sheets batchUpdate requests to a spreadsheet - escape hatch that unlocks the "
+            "full Sheets API Request surface not covered by other tools: charts (addChart), data validation "
+            "dropdowns (setDataValidation), protected/banded/named ranges, unmergeCells, "
+            "delete/duplicate/rename sheets, sortRange, findReplace, autoResizeDimensions, "
+            "insert/delete rows and columns, row/column grouping, filter views, slicers, and more. "
+            "Accepts a list of Request objects exactly as documented in the Sheets API batchUpdate reference; "
+            "up to 100 requests execute atomically in one API call."
+        ),
+        tags={
+            "sheets",
+            "batch",
+            "raw",
+            "charts",
+            "validation",
+            "escape-hatch",
+            "google",
+        },
+        annotations={
+            "title": "Batch Update Spreadsheet (Raw Requests)",
+            "readOnlyHint": False,
+            "destructiveHint": True,
+            "idempotentHint": False,
+            "openWorldHint": True,
+        },
+    )
+    async def batch_update_sheet(
+        spreadsheet_id: str,
+        requests: Annotated[
+            Union[str, List[dict]],
+            Field(
+                description=(
+                    "List of raw Sheets API Request objects (or a JSON string of that list). Each item is a "
+                    'single-key dict naming the request type, e.g. {"addChart": {...}}, '
+                    '{"setDataValidation": {"range": {...}, "rule": {"condition": {"type": "ONE_OF_LIST", '
+                    '"values": [{"userEnteredValue": "Active"}]}, "showCustomUi": true}}}, '
+                    '{"deleteSheet": {"sheetId": 123}}. Requests are applied atomically and in order.'
+                ),
+            ),
+        ],
+        user_google_email: UserGoogleEmailSheets = None,
+    ) -> BatchUpdateSheetResponse:
+        """
+        Applies raw batchUpdate requests to a spreadsheet.
+
+        Args:
+            spreadsheet_id (str): The ID of the spreadsheet. Required.
+            requests (Union[str, List[dict]]): List of raw Sheets API Request objects, or a JSON string of that list. Required.
+            user_google_email (str): The user's Google email address. Auto-injected by middleware if not provided.
+
+        Returns:
+            BatchUpdateSheetResponse: Structured response including per-request replies (e.g. created chart/sheet IDs).
+        """
+        logger.info(
+            f"[batch_update_sheet] Invoked. Email: '{user_google_email}', Spreadsheet: {spreadsheet_id}"
+        )
+
+        try:
+            try:
+                parsed_requests = _parse_json_list(requests, "requests")
+            except ValueError as e:
+                return BatchUpdateSheetResponse(
+                    spreadsheetId=spreadsheet_id,
+                    requestCount=0,
+                    success=False,
+                    message="",
+                    error=str(e),
+                )
+
+            if not parsed_requests or not all(
+                isinstance(req, dict) for req in parsed_requests
+            ):
+                return BatchUpdateSheetResponse(
+                    spreadsheetId=spreadsheet_id,
+                    requestCount=0,
+                    success=False,
+                    message="",
+                    error="'requests' must be a non-empty list of Request objects (dicts).",
+                )
+
+            sheets_service = await _get_sheets_service_with_fallback(user_google_email)
+
+            response = await asyncio.to_thread(
+                sheets_service.spreadsheets()
+                .batchUpdate(
+                    spreadsheetId=spreadsheet_id,
+                    body={"requests": parsed_requests},
+                )
+                .execute
+            )
+
+            replies = response.get("replies", [])
+
+            logger.info(
+                f"Successfully applied {len(parsed_requests)} batchUpdate requests for {user_google_email}."
+            )
+
+            return BatchUpdateSheetResponse(
+                spreadsheetId=spreadsheet_id,
+                requestCount=len(parsed_requests),
+                replies=replies,
+                success=True,
+                message=f"Successfully applied {len(parsed_requests)} requests to spreadsheet {spreadsheet_id}.",
+            )
+
+        except HttpError as e:
+            error_msg = f"Failed to apply batch update: {e}"
+            logger.error(f"❌ {error_msg}")
+            return BatchUpdateSheetResponse(
+                spreadsheetId=spreadsheet_id,
+                requestCount=0,
+                success=False,
+                message="",
+                error=error_msg,
+            )
+        except Exception as e:
+            error_msg = f"Unexpected error applying batch update: {str(e)}"
+            logger.error(f"❌ {error_msg}")
+            return BatchUpdateSheetResponse(
+                spreadsheetId=spreadsheet_id,
+                requestCount=0,
+                success=False,
+                message="",
+                error=error_msg,
+            )
+
+    @mcp.tool(
+        name="batch_modify_sheet_values",
+        description=(
+            "Write values to multiple ranges of a Google Sheet in a single API call, and/or clear multiple "
+            "ranges - the batch counterpart to modify_sheet_values for multi-range workloads"
+        ),
+        tags={"sheets", "write", "batch", "clear", "google"},
+        annotations={
+            "title": "Batch Modify Sheet Values",
+            "readOnlyHint": False,
+            "destructiveHint": True,
+            "idempotentHint": False,
+            "openWorldHint": True,
+        },
+    )
+    async def batch_modify_sheet_values(
+        spreadsheet_id: str,
+        data: Annotated[
+            Optional[Union[str, List[dict]]],
+            Field(
+                default=None,
+                description=(
+                    "List of write payloads (or a JSON string of that list), each "
+                    '{"range": "Sheet1!A1:B2", "values": [["a", 1], ["b", 2]]}. Cells may be strings, '
+                    "numbers, booleans, or null. All ranges are written in one API call."
+                ),
+            ),
+        ] = None,
+        value_input_option: Annotated[
+            str,
+            Field(
+                default="USER_ENTERED",
+                description="How to interpret input values: 'RAW' (values not parsed) or 'USER_ENTERED' (values parsed as if typed by user)",
+            ),
+        ] = "USER_ENTERED",
+        clear_ranges: Annotated[
+            Optional[Union[str, List[str]]],
+            Field(
+                default=None,
+                description='List of ranges to clear (or a JSON string of that list), e.g. ["Sheet1!A1:B2", "Sheet2!C:C"]. Cleared before any writes.',
+            ),
+        ] = None,
+        user_google_email: UserGoogleEmailSheets = None,
+    ) -> BatchModifyValuesResponse:
+        """
+        Writes values to multiple ranges and/or clears multiple ranges in single batched API calls.
+
+        Args:
+            spreadsheet_id (str): The ID of the spreadsheet. Required.
+            data (Optional[Union[str, List[dict]]]): List of {"range": ..., "values": [[...]]} write payloads. Can be Python list or JSON string.
+            value_input_option (str): How to interpret input values ("RAW" or "USER_ENTERED"). Defaults to "USER_ENTERED".
+            clear_ranges (Optional[Union[str, List[str]]]): Ranges to clear (before writes). Can be Python list or JSON string.
+            user_google_email (str): The user's Google email address. Auto-injected by middleware if not provided.
+
+        Returns:
+            BatchModifyValuesResponse: Structured response with totals across all ranges.
+        """
+        logger.info(
+            f"[batch_modify_sheet_values] Invoked. Email: '{user_google_email}', Spreadsheet: {spreadsheet_id}"
+        )
+
+        try:
+            try:
+                parsed_data = _parse_json_list(data, "data") if data else None
+                parsed_clear_ranges = (
+                    _parse_json_list(clear_ranges, "clear_ranges")
+                    if clear_ranges
+                    else None
+                )
+            except ValueError as e:
+                return BatchModifyValuesResponse(
+                    spreadsheetId=spreadsheet_id,
+                    success=False,
+                    message="",
+                    error=str(e),
+                )
+
+            if not parsed_data and not parsed_clear_ranges:
+                return BatchModifyValuesResponse(
+                    spreadsheetId=spreadsheet_id,
+                    success=False,
+                    message="",
+                    error="Either 'data' or 'clear_ranges' must be provided.",
+                )
+
+            if parsed_data:
+                for entry in parsed_data:
+                    if (
+                        not isinstance(entry, dict)
+                        or "range" not in entry
+                        or not isinstance(entry.get("values"), list)
+                    ):
+                        return BatchModifyValuesResponse(
+                            spreadsheetId=spreadsheet_id,
+                            success=False,
+                            message="",
+                            error='Each data entry must be a dict with "range" and "values" keys.',
+                        )
+                    validation_error = _validate_2d_values(entry["values"])
+                    if validation_error:
+                        return BatchModifyValuesResponse(
+                            spreadsheetId=spreadsheet_id,
+                            success=False,
+                            message="",
+                            error=f"Invalid values for range '{entry['range']}': {validation_error}",
+                        )
+
+            if parsed_clear_ranges and not all(
+                isinstance(r, str) for r in parsed_clear_ranges
+            ):
+                return BatchModifyValuesResponse(
+                    spreadsheetId=spreadsheet_id,
+                    success=False,
+                    message="",
+                    error="'clear_ranges' must be a list of A1-notation range strings.",
+                )
+
+            sheets_service = await _get_sheets_service_with_fallback(user_google_email)
+
+            cleared: Optional[List[str]] = None
+            if parsed_clear_ranges:
+                clear_result = await asyncio.to_thread(
+                    sheets_service.spreadsheets()
+                    .values()
+                    .batchClear(
+                        spreadsheetId=spreadsheet_id,
+                        body={"ranges": parsed_clear_ranges},
+                    )
+                    .execute
+                )
+                cleared = clear_result.get("clearedRanges", parsed_clear_ranges)
+
+            total_updated_cells: Optional[int] = None
+            total_updated_ranges: Optional[int] = None
+            if parsed_data:
+                write_result = await asyncio.to_thread(
+                    sheets_service.spreadsheets()
+                    .values()
+                    .batchUpdate(
+                        spreadsheetId=spreadsheet_id,
+                        body={
+                            "valueInputOption": value_input_option,
+                            "data": [
+                                {
+                                    "range": entry["range"],
+                                    "values": entry["values"],
+                                }
+                                for entry in parsed_data
+                            ],
+                        },
+                    )
+                    .execute
+                )
+                total_updated_cells = write_result.get("totalUpdatedCells", 0)
+                total_updated_ranges = len(write_result.get("responses", parsed_data))
+
+            parts = []
+            if cleared:
+                parts.append(f"cleared {len(cleared)} ranges")
+            if parsed_data:
+                parts.append(
+                    f"updated {total_updated_cells} cells across {total_updated_ranges} ranges"
+                )
+
+            message = (
+                f"Successfully {' and '.join(parts)} in spreadsheet {spreadsheet_id}."
+            )
+            logger.info(f"[batch_modify_sheet_values] {message}")
+
+            return BatchModifyValuesResponse(
+                spreadsheetId=spreadsheet_id,
+                totalUpdatedCells=total_updated_cells,
+                totalUpdatedRanges=total_updated_ranges,
+                clearedRanges=cleared,
+                success=True,
+                message=message,
+            )
+
+        except HttpError as e:
+            error_msg = f"Failed to batch modify sheet values: {e}"
+            logger.error(f"❌ {error_msg}")
+            return BatchModifyValuesResponse(
+                spreadsheetId=spreadsheet_id,
+                success=False,
+                message="",
+                error=error_msg,
+            )
+        except Exception as e:
+            error_msg = f"Unexpected error batch modifying sheet values: {str(e)}"
+            logger.error(f"❌ {error_msg}")
+            return BatchModifyValuesResponse(
+                spreadsheetId=spreadsheet_id,
                 success=False,
                 message="",
                 error=error_msg,

--- a/sheets/sheets_types.py
+++ b/sheets/sheets_types.py
@@ -6,7 +6,7 @@ enabling FastMCP to automatically generate JSON schemas for better MCP client in
 """
 
 from pydantic import BaseModel, Field
-from typing_extensions import List, Optional
+from typing_extensions import Any, List, Optional
 
 
 class SpreadsheetInfo(BaseModel):
@@ -56,6 +56,10 @@ class SpreadsheetDetailsResponse(BaseModel):
     spreadsheetUrl: Optional[str] = Field(
         None, description="Web URL for the spreadsheet"
     )
+    raw: Optional[dict] = Field(
+        None,
+        description="Raw spreadsheets.get response when a 'fields' mask was requested (formatting, charts, conditional formats, etc.)",
+    )
     error: Optional[str] = Field(None, description="Error message if operation failed")
 
 
@@ -64,7 +68,10 @@ class SheetValuesResponse(BaseModel):
 
     spreadsheetId: str = Field(..., description="Unique identifier for the spreadsheet")
     range: str = Field(..., description="Range that was read from the sheet")
-    values: List[List[str]] = Field(..., description="2D array of cell values")
+    values: List[List[Any]] = Field(
+        ...,
+        description="2D array of cell values. Cells are strings for FORMATTED_VALUE/FORMULA rendering, but may be numbers or booleans with UNFORMATTED_VALUE.",
+    )
     rowCount: int = Field(..., description="Number of rows returned")
     columnCount: int = Field(..., description="Number of columns returned")
     error: Optional[str] = Field(None, description="Error message if operation failed")
@@ -76,7 +83,11 @@ class SheetModifyResponse(BaseModel):
     spreadsheetId: str = Field(..., description="Unique identifier for the spreadsheet")
     range: str = Field(..., description="Range that was modified")
     operation: str = Field(
-        ..., description="Type of operation performed ('update', 'clear')"
+        ..., description="Type of operation performed ('update', 'append', 'clear')"
+    )
+    updatedRange: Optional[str] = Field(
+        None,
+        description="Actual range that was written (useful for 'append', where the API chooses the range)",
     )
     updatedCells: Optional[int] = Field(None, description="Number of cells updated")
     updatedRows: Optional[int] = Field(None, description="Number of rows updated")
@@ -161,6 +172,38 @@ class MergeCellsResponse(BaseModel):
     range: str = Field(..., description="Cell range that was merged")
     mergeType: str = Field(..., description="Type of merge operation performed")
     success: bool = Field(..., description="Whether the merge succeeded")
+    message: str = Field(..., description="Success or error message")
+    error: Optional[str] = Field(None, description="Error message if operation failed")
+
+
+class BatchUpdateSheetResponse(BaseModel):
+    """Response structure for batch_update_sheet tool."""
+
+    spreadsheetId: str = Field(..., description="Unique identifier for the spreadsheet")
+    requestCount: int = Field(..., description="Number of requests submitted")
+    replies: Optional[List[dict]] = Field(
+        None,
+        description="Per-request replies from the API (e.g. addChart returns the chart ID, addSheet returns sheet properties)",
+    )
+    success: bool = Field(..., description="Whether the batch update succeeded")
+    message: str = Field(..., description="Success or error message")
+    error: Optional[str] = Field(None, description="Error message if operation failed")
+
+
+class BatchModifyValuesResponse(BaseModel):
+    """Response structure for batch_modify_sheet_values tool."""
+
+    spreadsheetId: str = Field(..., description="Unique identifier for the spreadsheet")
+    totalUpdatedCells: Optional[int] = Field(
+        None, description="Total number of cells updated across all ranges"
+    )
+    totalUpdatedRanges: Optional[int] = Field(
+        None, description="Number of ranges written"
+    )
+    clearedRanges: Optional[List[str]] = Field(
+        None, description="Ranges that were cleared"
+    )
+    success: bool = Field(..., description="Whether the batch operation succeeded")
     message: str = Field(..., description="Success or error message")
     error: Optional[str] = Field(None, description="Error message if operation failed")
 

--- a/skills/server_skill_generator.py
+++ b/skills/server_skill_generator.py
@@ -329,7 +329,7 @@ to see currently active tools.
 | **Chat Cards** | `send_simple_card`, `send_rich_card`, `send_enhanced_card`, `send_interactive_card`, `send_smart_card`, `preview_card_from_description`, `validate_card`, `find_card_templates`, `save_card_template` |
 | **Calendar** | `list_calendars`, `list_events`, `create_event`, `modify_event`, `delete_event`, `get_event`, `create_calendar`, `bulk_calendar_operations`, `move_events_between_calendars` |
 | **Docs** | `search_docs`, `get_doc_content`, `list_docs_in_folder`, `create_doc` |
-| **Sheets** | `list_spreadsheets`, `get_spreadsheet_info`, `read_sheet_values`, `modify_sheet_values`, `create_spreadsheet`, `create_sheet`, `format_sheet_range` |
+| **Sheets** | `list_spreadsheets`, `get_spreadsheet_info`, `read_sheet_values`, `modify_sheet_values`, `batch_modify_sheet_values`, `create_spreadsheet`, `create_sheet`, `format_sheet_range`, `batch_update_sheet` |
 | **Slides** | `create_presentation`, `get_presentation_info`, `add_slide`, `update_slide_content`, `export_and_download_presentation` |
 | **Forms** | `create_form`, `add_questions_to_form`, `get_form`, `set_form_publish_state`, `publish_form_publicly`, `get_form_response`, `list_form_responses`, `update_form_questions` |
 | **Photos** | `list_photos_albums`, `search_photos`, `upload_photos`, `upload_folder_photos`, `photos_smart_search`, `photos_batch_details`, `create_photos_album`, `get_photo_details` |

--- a/skills/server_skill_generator.py
+++ b/skills/server_skill_generator.py
@@ -291,6 +291,31 @@ Supported services: `gmail`, `drive`, `calendar`, `docs`, `sheets`, `chat`, `for
 | `gmail://messages/recent` | Recent Gmail messages |
 | `tools://list/all` | All available tools |"""
 
+_SHEETS_POWER_SECTION = """\
+## Sheets Power Tools
+
+Beyond simple reads/writes, three tools cover advanced spreadsheet work:
+
+- **`batch_update_sheet`** — raw `spreadsheets.batchUpdate` passthrough (up to 100 requests,
+  atomic: one bad request rolls back the whole batch). This is the route to everything the
+  dedicated tools don't cover: **charts** (`addChart` — all 9 chart families: basic
+  BAR/LINE/AREA/COLUMN/SCATTER/COMBO/STEPPED_AREA, pie, bubble, candlestick, histogram, org,
+  scorecard, treemap, waterfall), **data-validation dropdowns** (`setDataValidation` with
+  `ONE_OF_LIST` + `showCustomUi`), protected/banded/named ranges, `unmergeCells`,
+  delete/duplicate/rename sheets, `sortRange`, `findReplace`, `autoResizeDimensions`,
+  row/column grouping, filter views, and slicers. Request objects follow the Sheets API
+  batchUpdate reference verbatim; replies return created IDs (e.g. chart IDs).
+  Gotcha: BAR chart series must target `BOTTOM_AXIS`; other basic charts use `LEFT_AXIS`.
+- **`batch_modify_sheet_values`** — write many ranges and/or clear ranges in single API calls;
+  prefer it over looping `modify_sheet_values` whenever touching more than ~2 ranges.
+- **`get_spreadsheet_info` with `fields`** — read back formatting, conditional-format rules,
+  charts, merges, and validation via a Google API field mask (raw response in `raw`), e.g.
+  `sheets(properties,charts(chartId,spec(title)))`. Scope grid-data masks tightly.
+
+Cell values are real scalars: numbers/booleans round-trip properly (`RAW` input writes real
+numbers; `UNFORMATTED_VALUE` reads them back typed). `modify_sheet_values` also supports
+`append=True` to add rows after existing data."""
+
 _SKILL_RESOURCES_SECTION = """\
 ## Skill Resources
 
@@ -642,6 +667,10 @@ def generate_server_skill(
         "---",
         "",
         _SERVICES_SECTION,
+        "",
+        "---",
+        "",
+        _SHEETS_POWER_SECTION,
         "",
         "---",
         "",

--- a/tests/client/test_sheets_tools.py
+++ b/tests/client/test_sheets_tools.py
@@ -81,9 +81,11 @@ class TestSheetsTools:
             "get_spreadsheet_info",
             "read_sheet_values",
             "modify_sheet_values",
+            "batch_modify_sheet_values",  # Multi-range write/clear
             "create_spreadsheet",
             "create_sheet",
             "format_sheet_range",  # Master formatting tool
+            "batch_update_sheet",  # Raw batchUpdate escape hatch (charts, validation, ...)
         ]
 
         await assert_tools_registered(client, expected_tools, context="Sheets tools")

--- a/tests/data/tool_schema_snapshot.json
+++ b/tests/data/tool_schema_snapshot.json
@@ -10,6 +10,18 @@
     "presentation_id",
     "user_google_email"
   ],
+  "batch_modify_sheet_values": [
+    "clear_ranges",
+    "data",
+    "spreadsheet_id",
+    "user_google_email",
+    "value_input_option"
+  ],
+  "batch_update_sheet": [
+    "requests",
+    "spreadsheet_id",
+    "user_google_email"
+  ],
   "bulk_calendar_operations": [
     "attendee_email",
     "calendar_id",
@@ -301,6 +313,7 @@
     "user_google_email"
   ],
   "get_spreadsheet_info": [
+    "fields",
     "spreadsheet_id",
     "user_google_email"
   ],
@@ -463,6 +476,7 @@
     "user_google_email"
   ],
   "modify_sheet_values": [
+    "append",
     "clear_values",
     "range_name",
     "spreadsheet_id",

--- a/tests/test_sheets_values_typing.py
+++ b/tests/test_sheets_values_typing.py
@@ -1,0 +1,53 @@
+"""Unit tests for Sheets value typing and validation fixes.
+
+Guards the fixes for:
+- read_sheet_values crashing on numeric/boolean cells returned by
+  value_render_option="UNFORMATTED_VALUE" (SheetValuesResponse.values was
+  typed List[List[str]]).
+- modify_sheet_values rejecting non-string cells, making it impossible to
+  write real numbers/booleans with valueInputOption="RAW".
+"""
+
+from sheets.sheets_tools import _validate_2d_values
+from sheets.sheets_types import SheetValuesResponse
+
+
+class TestSheetValuesResponseTyping:
+    def test_accepts_unformatted_value_cells(self):
+        """UNFORMATTED_VALUE reads return floats/ints/bools — must not raise."""
+        response = SheetValuesResponse(
+            spreadsheetId="abc",
+            range="Sheet1!A1:D2",
+            values=[[1.5, 2, True, "text"], ["", None, -3, 0.0]],
+            rowCount=2,
+            columnCount=4,
+        )
+        assert response.values[0][0] == 1.5
+        assert response.values[0][2] is True
+
+    def test_accepts_formatted_string_cells(self):
+        response = SheetValuesResponse(
+            spreadsheetId="abc",
+            range="A1",
+            values=[["$1,234.00"]],
+            rowCount=1,
+            columnCount=1,
+        )
+        assert response.values == [["$1,234.00"]]
+
+
+class TestValidate2DValues:
+    def test_accepts_scalar_cells(self):
+        assert _validate_2d_values([["a", 1, 2.5, True, None]]) is None
+
+    def test_accepts_empty_rows(self):
+        assert _validate_2d_values([[], ["x"]]) is None
+
+    def test_rejects_nested_lists(self):
+        assert _validate_2d_values([[["nested"]]]) is not None
+
+    def test_rejects_dict_cells(self):
+        assert _validate_2d_values([[{"not": "a scalar"}]]) is not None
+
+    def test_rejects_non_list_rows(self):
+        assert _validate_2d_values(["not-a-row"]) is not None

--- a/uv.lock
+++ b/uv.lock
@@ -1165,7 +1165,7 @@ wheels = [
 
 [[package]]
 name = "google-workspace-unlimited"
-version = "2.5.2"
+version = "2.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiodebug" },


### PR DESCRIPTION
## Summary

Closes the two gaps flagged by the Kitchen Sink Workbook exercise (no chart endpoint, no data-validation endpoint) — both were tool-surface gaps, not SDK limits — and fixes four real bugs found while auditing the sheets module.

### New tools
- **`batch_update_sheet`** — raw `spreadsheets.batchUpdate` passthrough (up to 100 requests, atomic, replies returned). Unlocks the full 69-type Request surface: charts (`addChart`), data-validation dropdowns (`setDataValidation`), protected/banded/named ranges, `unmergeCells`, sheet delete/duplicate/rename, `sortRange`, `findReplace`, `autoResizeDimensions`, row/column grouping, filter views, slicers, …
- **`batch_modify_sheet_values`** — multi-range write + clear in single API calls (`values.batchUpdate` / `values.batchClear`). Collapses N single-range writes into one call.

### Enhancements
- `modify_sheet_values`: new `append` mode (`values.append`, INSERT_ROWS) and scalar cells — numbers/booleans/null are now writable (real numeric values with RAW input).
- `get_spreadsheet_info`: optional `fields` mask for reading back formatting, conditional-format rules, charts, merges, and validation; raw API response returned in `raw`.

### Fixes (all reproduced before fixing)
- `read_sheet_values` crashed with a Pydantic `ValidationError` on `UNFORMATTED_VALUE` reads — `values` was typed `List[List[str]]` but the API returns numbers/booleans.
- `format_sheet_range` `merge_cells_option="UNMERGE"` sent `mergeType: "UNMERGE"`, which is not in the API's MergeType enum (`MERGE_ALL|MERGE_COLUMNS|MERGE_ROWS`) — it now emits an `unmergeCells` request. This option had never worked.
- `format_sheet_range` claimed `idempotentHint: True` but stacks a new conditional-format rule at index 0 on every call — corrected to False.
- `modify_sheet_values` rejected non-string cells, silently forcing all RAW writes to text.

## Test plan
- New unit tests `tests/test_sheets_values_typing.py` (mixed-type response model + 2D value validation) — 7 passed.
- Tool-schema snapshot regenerated (`UPDATE_TOOL_SCHEMA_SNAPSHOT=1`) — new tools and params registered on the in-process server.
- `tests/client/test_sheets_tools.py` registration list updated with both new tools.
- `ruff check .` and `ruff format --check .` both clean.

Version bumped 2.5.2 → 2.6.0 in `pyproject.toml` and `uv.lock` per the release pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)