### PR TITLE
Release 2.6.2 — Photos: upload fixes + client-filesystem transport

### DIFF
--- a/photos/advanced_tools.py
+++ b/photos/advanced_tools.py
@@ -121,6 +121,154 @@ async def _get_optimized_photos_client(user_google_email: str) -> OptimizedPhoto
     return client
 
 
+class _ClientFsStaging:
+    """Result of staging client-filesystem photo uploads (see _stage_client_fs_photos)."""
+
+    def __init__(self) -> None:
+        self.pending_response: Optional[PhotoUploadResponse] = None
+        self.local_paths: List[str] = []
+        self.path_map: Dict[str, str] = {}  # temp path -> original client path
+        self.upload_ids: List[str] = []
+        self.temp_dir: Optional[str] = None
+
+    def remap(self, results: Dict) -> None:
+        """Rewrite temp paths in upload results back to the client's paths."""
+        for bucket in ("successful", "failed"):
+            for entry in results.get(bucket, []):
+                entry["file"] = self.path_map.get(entry.get("file"), entry.get("file"))
+
+    def cleanup(self) -> None:
+        import shutil
+
+        from drive.upload_staging import consume_allocation
+
+        for uid in self.upload_ids:
+            try:
+                consume_allocation(uid)
+            except Exception:
+                pass
+        if self.temp_dir:
+            shutil.rmtree(self.temp_dir, ignore_errors=True)
+            self.temp_dir = None
+
+
+async def _stage_client_fs_photos(
+    file_list: List[str], user_email: Optional[str]
+) -> _ClientFsStaging:
+    """Two-phase client→server transport for photo uploads.
+
+    Mirrors upload_to_drive's client-filesystem mode and reuses the same
+    staging store and ``PUT /drive-upload`` endpoint (the transport is not
+    Drive-specific: bytes are staged keyed by (session, client path)).
+
+    Phase 1: any path without staged bytes gets an HMAC-signed one-time PUT
+    URL; ``pending_response`` is set and the tool returns it.
+    Phase 2: all paths staged — bytes are materialized into a temp dir under
+    their original basenames and the normal upload flow runs on those local
+    paths. Call ``cleanup()`` when done.
+    """
+    import tempfile
+
+    from auth.context import get_session_context
+    from config.settings import settings
+    from drive.upload_staging import (
+        allocate_upload,
+        find_allocation_by_path,
+        generate_upload_url,
+        read_staged_bytes,
+    )
+
+    ctx = _ClientFsStaging()
+    session_id = await get_session_context()
+    if not session_id:
+        ctx.pending_response = PhotoUploadResponse(
+            success=False,
+            total_count=len(file_list),
+            failed_count=len(file_list),
+            failed=[{"file": p, "error": "no MCP session"} for p in file_list],
+            user_email=user_email,
+            text_summary=(
+                "Client-filesystem upload mode requires an MCP session (none "
+                "found). Set DRIVE_UPLOAD_CLIENT_FS=false for stdio / "
+                "server-local uploads."
+            ),
+            error="Client-filesystem upload mode requires an MCP session.",
+        )
+        return ctx
+
+    staged = []
+    pending = []
+    for path in file_list:
+        alloc = find_allocation_by_path(session_id, path)
+        if alloc and alloc.received:
+            staged.append((path, alloc))
+            continue
+        new_alloc = allocate_upload(
+            session_id=session_id,
+            client_path=path,
+            user_email=user_email or "",
+            folder_id="",
+            custom_filename=None,
+        )
+        ttl = settings.drive_upload_ttl_seconds
+        url, exp_ts = generate_upload_url(settings.base_url, new_alloc.upload_id, ttl)
+        safe_path = path.replace('"', '\\"')
+        pending.append(
+            {
+                "file": path,
+                "uploadId": new_alloc.upload_id,
+                "uploadUrl": url,
+                "method": "PUT",
+                "expiresAt": exp_ts,
+                "expiresInSeconds": ttl,
+                "curlExample": f'curl -X PUT --data-binary @"{safe_path}" "{url}"',
+            }
+        )
+
+    if pending:
+        ctx.pending_response = PhotoUploadResponse(
+            success=False,
+            total_count=len(file_list),
+            pending_uploads=pending,
+            user_email=user_email,
+            text_summary=(
+                "Upload pending: client filesystem mode is active. PUT each "
+                "file's bytes to its uploadUrl (one-time use, expires), then "
+                "re-call upload_photos with the same file_paths to finalize."
+            ),
+        )
+        return ctx
+
+    # Phase 2 — materialize staged bytes under their original basenames so
+    # Google Photos records the real filename.
+    ctx.temp_dir = tempfile.mkdtemp(prefix="photos-clientfs-")
+    for path, alloc in staged:
+        data = read_staged_bytes(alloc.upload_id)
+        if data is None:
+            ctx.cleanup()
+            ctx.pending_response = PhotoUploadResponse(
+                success=False,
+                total_count=len(file_list),
+                failed_count=len(file_list),
+                failed=[{"file": path, "error": "staged bytes unreadable"}],
+                user_email=user_email,
+                text_summary=(
+                    f"Staged upload for '{path}' could not be read from disk. "
+                    "Re-call upload_photos to restart the transfer."
+                ),
+                error="Staged upload could not be read from disk.",
+            )
+            return ctx
+        local = os.path.join(ctx.temp_dir, os.path.basename(path))
+        with open(local, "wb") as fh:
+            fh.write(data)
+        ctx.local_paths.append(local)
+        ctx.path_map[local] = path
+        ctx.upload_ids.append(alloc.upload_id)
+
+    return ctx
+
+
 def setup_advanced_photos_tools(mcp: FastMCP) -> None:
     """
     Setup advanced Google Photos tools with optimization features.
@@ -807,6 +955,7 @@ def setup_advanced_photos_tools(mcp: FastMCP) -> None:
             "Upload one local photo (string path) or a batch (list of paths) to Google Photos, optionally adding them to an existing album (album_id) or a newly created one (create_album).\n"
             "Use when: uploading specific files. To upload a whole directory, use upload_folder_photos instead.\n"
             "Behavior: writes to the user's library; batch items are independent — some can succeed while others fail, and partial success is NOT reported as an error. If create_album fails, uploads continue without an album.\n"
+            "Client-filesystem deployments (DRIVE_UPLOAD_CLIENT_FS=true): paths are read from the CLIENT's machine via a two-phase handshake — the first call returns pending_uploads with signed PUT URLs; PUT each file's bytes, then re-call with the same file_paths to finalize.\n"
             "Returns: successful[] and failed[] lists with per-file detail plus totals. Errors: per-file entries in failed[] (missing path, unsupported format, quota); auth failures fail the whole call."
         ),
         tags={"photos", "upload", "batch", "single", "google"},
@@ -855,6 +1004,17 @@ def setup_advanced_photos_tools(mcp: FastMCP) -> None:
             f"[upload_photos] User: {user_google_email}, Files: {len(file_list)}, Single: {is_single_upload}"
         )
 
+        # Client-filesystem mode: paths live on the MCP client, not this
+        # server. Stage bytes via the shared PUT /drive-upload endpoint.
+        staging: Optional[_ClientFsStaging] = None
+        from config.settings import settings as _settings
+
+        if _settings.drive_upload_client_fs:
+            staging = await _stage_client_fs_photos(file_list, user_google_email)
+            if staging.pending_response is not None:
+                return staging.pending_response
+            file_list = staging.local_paths
+
         try:
             client = await _get_optimized_photos_client(user_google_email)
 
@@ -874,7 +1034,9 @@ def setup_advanced_photos_tools(mcp: FastMCP) -> None:
             if is_single_upload:
                 # For single photo, use the individual upload method
                 try:
-                    media_item = await client.upload_photo(file_list[0], description)
+                    media_item = await client.upload_photo(
+                        file_list[0], description, album_id=target_album_id
+                    )
                     results = {
                         "successful": [
                             {
@@ -895,6 +1057,9 @@ def setup_advanced_photos_tools(mcp: FastMCP) -> None:
             else:
                 # For multiple photos, use batch processing
                 results = await client.upload_photos_batch(file_list, target_album_id)
+
+            if staging is not None:
+                staging.remap(results)
 
             elapsed_time = (datetime.now() - start_time).total_seconds()
             cache_stats = await client.get_cache_stats()
@@ -1047,6 +1212,9 @@ def setup_advanced_photos_tools(mcp: FastMCP) -> None:
                 text_summary=f"❌ **Upload Failed:** {error_msg}",
                 error=error_msg,
             )
+        finally:
+            if staging is not None:
+                staging.cleanup()
 
     @mcp.tool(
         name="upload_folder_photos",

--- a/photos/optimized_client.py
+++ b/photos/optimized_client.py
@@ -357,7 +357,7 @@ class OptimizedPhotosClient:
             logger.debug(f"Cleared {len(keys_to_remove)} album cache entries")
 
     async def upload_photo(
-        self, file_path: str, description: str = ""
+        self, file_path: str, description: str = "", album_id: Optional[str] = None
     ) -> Dict[str, Any]:
         """Upload a single photo to Google Photos."""
         logger.info(f"Uploading photo: {file_path}")
@@ -373,9 +373,12 @@ class OptimizedPhotosClient:
         # Step 1: Upload the media content
         upload_token = await self._upload_media_content(file_path)
 
-        # Step 2: Create the media item
+        # Step 2: Create the media item (attached to album_id when given —
+        # the API only allows this for albums created by this app)
         filename = os.path.basename(file_path)
-        media_item = await self._create_media_item(upload_token, filename, description)
+        media_item = await self._create_media_item(
+            upload_token, filename, description, album_id=album_id
+        )
 
         logger.info(f"Successfully uploaded photo: {media_item.get('id')}")
         return media_item
@@ -493,7 +496,11 @@ class OptimizedPhotosClient:
         return upload_token
 
     async def _create_media_item(
-        self, upload_token: str, filename: str, description: str = ""
+        self,
+        upload_token: str,
+        filename: str,
+        description: str = "",
+        album_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Create media item from upload token."""
         new_media_item = {
@@ -502,6 +509,8 @@ class OptimizedPhotosClient:
         }
 
         batch_create_body = {"newMediaItems": [new_media_item]}
+        if album_id:
+            batch_create_body["albumId"] = album_id
 
         request = self.photos_service.mediaItems().batchCreate(body=batch_create_body)
         response = await self._make_request(request.execute)
@@ -511,7 +520,9 @@ class OptimizedPhotosClient:
             raise Exception("No media item results returned")
 
         result = results[0]
-        if "status" in result and result["status"].get("code") != 0:
+        # google.rpc.Status omits `code` entirely when it is 0 (OK) — a
+        # successful result is `{"message": "Success"}` with no code field.
+        if "status" in result and result["status"].get("code", 0) != 0:
             raise Exception(f"Media item creation failed: {result['status']}")
 
         return result.get("mediaItem", {})
@@ -596,7 +607,8 @@ class OptimizedPhotosClient:
             for i, result in enumerate(media_results):
                 file_path = file_paths[i] if i < len(file_paths) else "unknown"
 
-                if "status" in result and result["status"].get("code") != 0:
+                # `code` is omitted when 0 (OK): {"message": "Success"} means success.
+                if "status" in result and result["status"].get("code", 0) != 0:
                     results["failed"].append(
                         {
                             "file": file_path,

--- a/photos/photos_types.py
+++ b/photos/photos_types.py
@@ -173,6 +173,14 @@ class PhotoUploadResponse(BaseModel):
         None, description="Human-readable summary of the upload operation"
     )
     error: Optional[str] = Field(None, description="Error message if operation failed")
+    pending_uploads: Optional[List[Dict[str, Any]]] = Field(
+        None,
+        description=(
+            "Client-filesystem mode only: per-file signed PUT URLs. PUT each "
+            "file's bytes to its uploadUrl, then re-call upload_photos with "
+            "the same file_paths to finalize."
+        ),
+    )
 
 
 # =============================================================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "google-workspace-unlimited"
-version = "2.6.1"
+version = "2.6.2"
 description = "Comprehensive MCP server for Google Workspace integration - 90+ tools across Gmail, Drive, Docs, Sheets, Slides, Calendar, Forms, Chat, and Photos with Code Mode tool discovery and OAuth 2.1 + PKCE authentication"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1165,7 +1165,7 @@ wheels = [
 
 [[package]]
 name = "google-workspace-unlimited"
-version = "2.6.1"
+version = "2.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiodebug" },


### PR DESCRIPTION
## What broke (found live while preparing the Google OAuth demo video)

1. **Every successful Photos upload was reported as a failure.** The Photos API returns `status: {"message": "Success"}` on success — `google.rpc.Status` omits `code` when it's 0/OK — so the check `result["status"].get("code") != 0` evaluated `None != 0` and threw on success. Fixed at both call sites (`.get("code", 0)`).
2. **Single-photo uploads ignored `album_id` entirely** — only the batch path attached to albums. `album_id` is now threaded through `upload_photo` → `_create_media_item` (`batchCreate.albumId`), so single uploads land in the requested album (app-created albums, per API rules).
3. **Over streamable HTTP there was no way to upload a client's image at all** — `upload_photos` only read server-local paths. It now supports client-filesystem deployments (`DRIVE_UPLOAD_CLIENT_FS=true`) by reusing the existing Drive staging + signed `PUT /drive-upload` endpoint in the same two-phase handshake as `upload_to_drive`: first call returns `pending_uploads` (per-file signed one-time PUT URLs) → client PUTs bytes → re-call with the same `file_paths` finalizes. Staged bytes are materialized under their original basenames (so Photos records real filenames), results are remapped back to client paths, and staging is consumed/cleaned in a `finally`.

No new endpoints, no new settings — the transport was already generic; Photos just never used it.

**Ships as 2.6.2** (version bumped in `pyproject.toml` + `uv.lock`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)