### PR TITLE
Release 2.7.0 — Photos: album rename via albums.patch (edit.appcreateddata)

### DIFF
--- a/photos/photos_tools.py
+++ b/photos/photos_tools.py
@@ -615,10 +615,13 @@ def setup_photos_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(
         name="create_photos_album",
-        description="Create a new album in Google Photos",
-        tags={"photos", "album", "create", "google"},
+        description=(
+            "Create a new album in Google Photos, or rename an existing "
+            "app-created album by passing its album_id"
+        ),
+        tags={"photos", "album", "create", "rename", "google"},
         annotations={
-            "title": "Create Photos Album",
+            "title": "Create or Rename Photos Album",
             "readOnlyHint": False,
             "destructiveHint": False,
             "idempotentHint": False,
@@ -626,37 +629,53 @@ def setup_photos_tools(mcp: FastMCP) -> None:
         },
     )
     async def create_photos_album(
-        user_google_email: str, title: str
+        user_google_email: str, title: str, album_id: Optional[str] = None
     ) -> CreateAlbumResponse:
         """
-        Create a new album in Google Photos.
+        Create a new album in Google Photos, or rename an existing one.
+
+        Renaming uses albums.patch, which requires the
+        photoslibrary.edit.appcreateddata scope and only works on albums
+        created by this app.
 
         Args:
             user_google_email (str): The user's Google email address. Required.
-            title (str): The title of the new album. Required.
+            title (str): The album title. Required.
+            album_id (Optional[str]): If provided, rename this app-created
+                album to `title` instead of creating a new album.
 
         Returns:
             CreateAlbumResponse: Structured response with album details.
         """
+        action = "rename" if album_id else "create"
         logger.info(
-            f"[create_photos_album] Invoked. Email: '{user_google_email}', Title: {title}"
+            f"[create_photos_album] Invoked. Email: '{user_google_email}', "
+            f"Title: {title}, Action: {action}"
         )
 
         try:
             photos_service = await _get_photos_service_with_fallback(user_google_email)
 
-            album_body = {"album": {"title": title}}
+            if album_id:
+                patch_request = photos_service.albums().patch(
+                    id=album_id, updateMask="title", body={"title": title}
+                )
+                album = await asyncio.to_thread(patch_request.execute)
+                message = (
+                    f"Successfully renamed album {album_id} to '{title}' "
+                    f"for {user_google_email}."
+                )
+            else:
+                album_body = {"album": {"title": title}}
+                create_request = photos_service.albums().create(body=album_body)
+                album = await asyncio.to_thread(create_request.execute)
+                album_id = album.get("id")
+                message = f"Successfully created album '{title}' for {user_google_email}. ID: {album_id}"
 
-            create_request = photos_service.albums().create(body=album_body)
-            album = await asyncio.to_thread(create_request.execute)
-
-            album_id = album.get("id")
             album_url = album.get("productUrl")
 
-            message = f"Successfully created album '{title}' for {user_google_email}. ID: {album_id}"
-
             logger.info(
-                f"Successfully created album for {user_google_email}. ID: {album_id}"
+                f"Successfully {action}d album for {user_google_email}. ID: {album_id}"
             )
 
             return CreateAlbumResponse(
@@ -669,23 +688,25 @@ def setup_photos_tools(mcp: FastMCP) -> None:
             )
 
         except HttpError as e:
-            error_msg = f"Failed to create album: {e}"
+            error_msg = f"Failed to {action} album: {e}"
             logger.error(error_msg)
             return CreateAlbumResponse(
                 success=False,
+                album_id=album_id,
                 album_title=title,
                 user_email=user_google_email,
-                message=f"Failed to create album: {e}",
+                message=error_msg,
                 error=error_msg,
             )
         except Exception as e:
-            error_msg = f"Unexpected error creating album: {str(e)}"
+            error_msg = f"Unexpected error during album {action}: {str(e)}"
             logger.error(error_msg)
             return CreateAlbumResponse(
                 success=False,
+                album_id=album_id,
                 album_title=title,
                 user_email=user_google_email,
-                message=f"Unexpected error creating album: {str(e)}",
+                message=error_msg,
                 error=error_msg,
             )
 

--- a/photos/photos_types.py
+++ b/photos/photos_types.py
@@ -395,11 +395,13 @@ class PhotoDetailsResponse(BaseModel):
 
 
 class CreateAlbumResponse(BaseModel):
-    """Response structure for create_photos_album tool."""
+    """Response structure for create_photos_album tool (create or rename)."""
 
-    success: bool = Field(True, description="Whether the album creation succeeded")
-    album_id: Optional[str] = Field(None, description="ID of the newly created album")
-    album_title: str = Field("", description="Title of the created album")
+    success: bool = Field(True, description="Whether the album create/rename succeeded")
+    album_id: Optional[str] = Field(
+        None, description="ID of the created or renamed album"
+    )
+    album_title: str = Field("", description="Title of the album")
     product_url: Optional[str] = Field(
         None, description="URL to view the album in Google Photos"
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "google-workspace-unlimited"
-version = "2.6.2"
+version = "2.7.0"
 description = "Comprehensive MCP server for Google Workspace integration - 90+ tools across Gmail, Drive, Docs, Sheets, Slides, Calendar, Forms, Chat, and Photos with Code Mode tool discovery and OAuth 2.1 + PKCE authentication"
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/data/tool_schema_snapshot.json
+++ b/tests/data/tool_schema_snapshot.json
@@ -113,6 +113,7 @@
     "user_google_email"
   ],
   "create_photos_album": [
+    "album_id",
     "title",
     "user_google_email"
   ],

--- a/tests/test_photos_album_rename.py
+++ b/tests/test_photos_album_rename.py
@@ -1,0 +1,98 @@
+"""
+Test create_photos_album's create-or-rename behavior.
+
+Renaming an app-created album uses albums.patch, which is the only
+Photos Library operation in this codebase that exercises the
+photoslibrary.edit.appcreateddata scope (Google's verification review
+requires every configured scope to map to a demonstrable feature).
+
+These tests mock the Photos service, so they run in every environment.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastmcp import FastMCP
+
+from photos.photos_tools import setup_photos_tools
+
+
+@pytest.fixture
+def create_album_fn():
+    import asyncio
+
+    mcp = FastMCP("test")
+    setup_photos_tools(mcp)
+    tool = asyncio.run(mcp.get_tool("create_photos_album"))
+    return tool.fn
+
+
+@pytest.fixture
+def mock_photos_service():
+    service = MagicMock()
+    with patch(
+        "photos.photos_tools._get_photos_service_with_fallback",
+        return_value=service,
+    ):
+        yield service
+
+
+@pytest.mark.asyncio
+async def test_create_mode_calls_albums_create(create_album_fn, mock_photos_service):
+    mock_photos_service.albums().create().execute.return_value = {
+        "id": "album-123",
+        "title": "My Album",
+        "productUrl": "https://photos.google.com/album/123",
+    }
+
+    result = await create_album_fn(
+        user_google_email="user@example.com", title="My Album"
+    )
+
+    assert result.success is True
+    assert result.album_id == "album-123"
+    assert result.album_title == "My Album"
+    mock_photos_service.albums().create.assert_called_with(
+        body={"album": {"title": "My Album"}}
+    )
+    mock_photos_service.albums().patch.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rename_mode_calls_albums_patch(create_album_fn, mock_photos_service):
+    mock_photos_service.albums().patch().execute.return_value = {
+        "id": "album-123",
+        "title": "New Title",
+        "productUrl": "https://photos.google.com/album/123",
+    }
+
+    result = await create_album_fn(
+        user_google_email="user@example.com",
+        title="New Title",
+        album_id="album-123",
+    )
+
+    assert result.success is True
+    assert result.album_id == "album-123"
+    assert result.album_title == "New Title"
+    assert "renamed" in result.message
+    mock_photos_service.albums().patch.assert_called_with(
+        id="album-123", updateMask="title", body={"title": "New Title"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_rename_failure_reports_error(create_album_fn, mock_photos_service):
+    mock_photos_service.albums().patch().execute.side_effect = RuntimeError(
+        "permission denied"
+    )
+
+    result = await create_album_fn(
+        user_google_email="user@example.com",
+        title="New Title",
+        album_id="album-123",
+    )
+
+    assert result.success is False
+    assert result.album_id == "album-123"
+    assert result.error is not None

--- a/uv.lock
+++ b/uv.lock
@@ -1165,7 +1165,7 @@ wheels = [
 
 [[package]]
 name = "google-workspace-unlimited"
-version = "2.6.2"
+version = "2.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiodebug" },


### PR DESCRIPTION
## Why

Google's OAuth verification review requires every scope configured in Cloud Console to map to a demonstrable feature. The app requests `photoslibrary.edit.appcreateddata` in the Photos flow, but no tool actually used it — a likely next rejection on least-privilege grounds. This PR gives the scope a real feature instead of dropping it.

## What

- **`create_photos_album` is now create-or-rename**: pass the new optional `album_id` to rename an existing app-created album via `albums.patch` (`updateMask=title`); omit it for the existing create behavior, which is unchanged.
- Tool description/annotations updated so MCP clients see both modes; `CreateAlbumResponse` field descriptions cover create and rename.
- New `tests/test_photos_album_rename.py` (mocked service): create mode calls `albums.create`, rename mode calls `albums.patch` with the exact expected args, and rename failures return a structured error.

## Verification

- `albums.patch` checked against the live Photos Library discovery document: it exists and requires exactly `https://www.googleapis.com/auth/photoslibrary.edit.appcreateddata` — no broader scope, and it only works on app-created albums, matching the consent-screen text.
- `pytest tests/test_photos_album_rename.py tests/test_photos_scope_separation.py tests/test_photos_token_group.py` — 35 passed.
- `ruff check .` and `ruff format --check .` clean.

## Release

- Version bumped 2.6.2 → 2.7.0 (minor: new tool capability) in both `pyproject.toml` and `uv.lock`.

## OAuth verification demo (for the video)

1. `upload_photos` → `photoslibrary.appendonly`
2. `list_photos_albums` / `list_album_photos` → `photoslibrary.readonly.appcreateddata`
3. `create_photos_album` with `album_id` (rename the demo album) → `photoslibrary.edit.appcreateddata`

🤖 Generated with [Claude Code](https://claude.com/claude-code)