### PR TITLE
Release 2.8.0 — OAuth scope trim: least-privilege

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -2,7 +2,7 @@
 
 **Effective date:** August 14, 2026
 
-RiversUnlimited Google Workspace MCP ("the App") is an open-source, **self-hosted** [Model Context Protocol](https://modelcontextprotocol.io) server that lets AI assistants you authorize (such as Claude) work with your Google Workspace data — Gmail, Drive, Docs, Sheets, Slides, Calendar, Forms, Chat, Tasks, Photos, and Contacts — on your behalf.
+RiversUnlimited Google Workspace MCP ("the App") is an open-source, **self-hosted** [Model Context Protocol](https://modelcontextprotocol.io) server that lets AI assistants you authorize (such as Claude) work with your Google Workspace data — Gmail, Drive, Docs, Sheets, Slides, Calendar, Forms, Chat, Photos, and Contacts — on your behalf.
 
 Because the App is self-hosted, **your data is processed on infrastructure operated by whoever runs the server instance** (typically you). There is no central service operated by the App's authors, and the App's authors never receive your data.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 [![google_workspace_fastmcp2 MCP server](https://glama.ai/mcp/servers/dipseth/google_workspace_fastmcp2/badges/card.svg)](https://glama.ai/mcp/servers/dipseth/google_workspace_fastmcp2)
 
-**GoogleUnlimited** is a comprehensive MCP framework that provides seamless Google Workspace integration through an advanced middleware architecture. It enables AI assistants and MCP clients to interact with Gmail, Google Drive, Docs, Sheets, Slides, Calendar, Forms, Chat, and Photos services using a unified, secure API.
+**GoogleUnlimited** is a comprehensive MCP framework that provides seamless Google Workspace integration through an advanced middleware architecture. It enables AI assistants and MCP clients to interact with Gmail, Google Drive, Docs, Sheets, Slides, Calendar, Forms, Chat, Photos, and Contacts (People API) services using a unified, secure API.
 
 **What sets it apart:**
 
@@ -330,7 +330,7 @@ ENABLE_CODE_MODE=false   # expose the full 90+ tool catalog instead
 
 ## 🎯 Service Capabilities
 
-GoogleUnlimited supports **9 Google Workspace services** with **90+ specialized tools**:
+GoogleUnlimited supports **10 Google Workspace services** with **90+ specialized tools**:
 
 | Service | Icon | Tools | Key Features | Documentation |
 |---------|------|-------|--------------|---------------|
@@ -343,9 +343,10 @@ GoogleUnlimited supports **9 Google Workspace services** with **90+ specialized 
 | **Forms** | 📝 | 8 | Creation, responses, validation, publishing | [`api-reference/forms/`](documentation/api-reference/forms/) |
 | **Chat** | 💬 | 24 | Messaging, cards, spaces, webhooks, unified cards | [`api-reference/chat/`](documentation/api-reference/chat/) |
 | **Photos** | 📷 | 12 | Albums, upload, search, metadata, smart search | [`api-reference/photos/`](documentation/api-reference/photos/) |
+| **People** | 👤 | 4 | Name→email search (contacts + org directory), contact labels | [`people/`](people/) |
 
 > 📚 **API Documentation Resources:**
-> - 🔗 **[Complete API Reference](documentation/api-reference/)** - Comprehensive documentation for all 92+ tools across 9 services
+> - 🔗 **[Complete API Reference](documentation/api-reference/)** - Comprehensive documentation for all 92+ tools across 10 services
 > - 📧 **[Gmail API Guide](documentation/api-reference/gmail/)** - Email management, labels, filters, and search operations
 > - 📁 **[Drive API Guide](documentation/api-reference/drive/)** - File operations, sharing, and Office document handling
 > - 📊 **[Sheets API Guide](documentation/api-reference/sheets/)** - Spreadsheet data manipulation and formatting

--- a/auth/compatibility_shim.py
+++ b/auth/compatibility_shim.py
@@ -219,6 +219,7 @@ class CompatibilityShim:
                     "gmail_modify",
                     "gmail_labels",
                     "gmail_settings_basic",
+                    "gmail_settings_sharing",
                 ],
                 "version": "v1",
                 "description": "Gmail service",
@@ -349,9 +350,9 @@ class CompatibilityShim:
             ScopeRegistry.GOOGLE_API_SCOPES["drive"]["full"],
             # Gmail (modify covers read/send/compose/labels)
             ScopeRegistry.GOOGLE_API_SCOPES["gmail"]["modify"],
-            # Gmail settings needed for filters (settings.sharing
-            # intentionally absent — only filter forward-to needs it)
+            # Gmail settings needed for filters/forwarding
             ScopeRegistry.GOOGLE_API_SCOPES["gmail"]["settings_basic"],
+            ScopeRegistry.GOOGLE_API_SCOPES["gmail"]["settings_sharing"],
         ]
 
         return " ".join(default_scopes)

--- a/auth/compatibility_shim.py
+++ b/auth/compatibility_shim.py
@@ -219,7 +219,6 @@ class CompatibilityShim:
                     "gmail_modify",
                     "gmail_labels",
                     "gmail_settings_basic",
-                    "gmail_settings_sharing",
                 ],
                 "version": "v1",
                 "description": "Gmail service",
@@ -350,9 +349,9 @@ class CompatibilityShim:
             ScopeRegistry.GOOGLE_API_SCOPES["drive"]["full"],
             # Gmail (modify covers read/send/compose/labels)
             ScopeRegistry.GOOGLE_API_SCOPES["gmail"]["modify"],
-            # Gmail settings needed for filters/forwarding
+            # Gmail settings needed for filters (settings.sharing
+            # intentionally absent — only filter forward-to needs it)
             ScopeRegistry.GOOGLE_API_SCOPES["gmail"]["settings_basic"],
-            ScopeRegistry.GOOGLE_API_SCOPES["gmail"]["settings_sharing"],
         ]
 
         return " ".join(default_scopes)

--- a/auth/compatibility_shim.py
+++ b/auth/compatibility_shim.py
@@ -338,21 +338,18 @@ class CompatibilityShim:
         """
         logger.info("COMPATIBILITY: Generating legacy DCR scope defaults")
 
-        # Ensure DCR default scopes include Gmail Settings scopes so clients can request filters/forwarding
+        # Least-privilege defaults: full scopes cover their readonly/send/
+        # compose/labels variants, and Google's OAuth verification flags
+        # redundant narrow+full pairs.
         default_scopes = [
             # Base
             ScopeRegistry.GOOGLE_API_SCOPES["base"]["openid"],
             ScopeRegistry.GOOGLE_API_SCOPES["base"]["userinfo_email"],
             ScopeRegistry.GOOGLE_API_SCOPES["base"]["userinfo_profile"],
-            # Drive basics
-            ScopeRegistry.GOOGLE_API_SCOPES["drive"]["readonly"],
-            ScopeRegistry.GOOGLE_API_SCOPES["drive"]["file"],
-            # Gmail basics
-            ScopeRegistry.GOOGLE_API_SCOPES["gmail"]["readonly"],
-            ScopeRegistry.GOOGLE_API_SCOPES["gmail"]["send"],
-            ScopeRegistry.GOOGLE_API_SCOPES["gmail"]["compose"],
+            # Drive
+            ScopeRegistry.GOOGLE_API_SCOPES["drive"]["full"],
+            # Gmail (modify covers read/send/compose/labels)
             ScopeRegistry.GOOGLE_API_SCOPES["gmail"]["modify"],
-            ScopeRegistry.GOOGLE_API_SCOPES["gmail"]["labels"],
             # Gmail settings needed for filters/forwarding
             ScopeRegistry.GOOGLE_API_SCOPES["gmail"]["settings_basic"],
             ScopeRegistry.GOOGLE_API_SCOPES["gmail"]["settings_sharing"],

--- a/auth/fastmcp_oauth_endpoints.py
+++ b/auth/fastmcp_oauth_endpoints.py
@@ -42,6 +42,7 @@ _FALLBACK_OAUTH_SCOPES = [
     "https://www.googleapis.com/auth/gmail.readonly",
     # Ensure fallback advertises Gmail Settings so inspectors/clients know they’re supported
     "https://www.googleapis.com/auth/gmail.settings.basic",
+    "https://www.googleapis.com/auth/gmail.settings.sharing",
     "https://www.googleapis.com/auth/calendar.readonly",
 ]
 

--- a/auth/fastmcp_oauth_endpoints.py
+++ b/auth/fastmcp_oauth_endpoints.py
@@ -42,7 +42,6 @@ _FALLBACK_OAUTH_SCOPES = [
     "https://www.googleapis.com/auth/gmail.readonly",
     # Ensure fallback advertises Gmail Settings so inspectors/clients know they’re supported
     "https://www.googleapis.com/auth/gmail.settings.basic",
-    "https://www.googleapis.com/auth/gmail.settings.sharing",
     "https://www.googleapis.com/auth/calendar.readonly",
 ]
 

--- a/auth/google_oauth_auth.py
+++ b/auth/google_oauth_auth.py
@@ -80,17 +80,16 @@ def _get_oauth_metadata_scopes() -> list[str]:
         return shim.get_legacy_oauth_endpoint_scopes()
     except Exception as e:
         logger.warning(f"Failed to get OAuth scopes from compatibility shim: {e}")
-        # Fallback to hardcoded scopes
+        # Fallback to hardcoded scopes (least-privilege: full scopes only,
+        # no redundant readonly variants)
         return [
             "openid",
             "email",
             "profile",
-            "https://www.googleapis.com/auth/drive.readonly",
-            "https://www.googleapis.com/auth/drive.file",
-            "https://www.googleapis.com/auth/gmail.readonly",
-            "https://www.googleapis.com/auth/calendar.readonly",
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/gmail.modify",
             "https://www.googleapis.com/auth/calendar",
-            "https://www.googleapis.com/auth/chat.messages.readonly",
+            "https://www.googleapis.com/auth/chat.messages",
         ]
 
 

--- a/auth/scope_registry.py
+++ b/auth/scope_registry.py
@@ -346,23 +346,23 @@ class ScopeRegistry:
     SERVICE_SCOPE_GROUPS = {
         # Base OAuth scopes for user authentication
         "base": ["base.userinfo_email", "base.userinfo_profile", "base.openid"],
-        # Basic service combinations
+        # Basic service combinations.
+        # These are what tools request by default, so each must stay a
+        # subset of what the OAuth flows actually grant (oauth_comprehensive
+        # for Workspace services, photos_basic for Photos) — full scopes
+        # cover the readonly variants at the API level, and requesting
+        # narrower strings the token doesn't carry just produces
+        # "missing scopes" warnings.
         "drive_basic": [
             "base.userinfo_email",
             "base.openid",
             "drive.full",  # Full Drive access for MCP - required to access shared/organizational files
-            "drive.readonly",
-            "drive.file",
         ],
         "drive_full": ["base.userinfo_email", "base.openid", "drive.full"],
         "gmail_basic": [
             "base.userinfo_email",
             "base.openid",
-            "gmail.readonly",
-            "gmail.send",
-            "gmail.compose",
             "gmail.modify",
-            "gmail.labels",
             "gmail.settings_basic",
             "gmail.settings_sharing",
         ],
@@ -370,33 +370,27 @@ class ScopeRegistry:
         "calendar_basic": [
             "base.userinfo_email",
             "base.openid",
-            "calendar.readonly",
-            "calendar.events",
             "calendar.full",
         ],
         "calendar_full": ["base.userinfo_email", "base.openid", "calendar.full"],
         "docs_basic": [
             "base.userinfo_email",
             "base.openid",
-            "docs.readonly",
             "docs.full",
         ],
         "sheets_basic": [
             "base.userinfo_email",
             "base.openid",
-            "sheets.readonly",
             "sheets.full",
         ],
         "chat_basic": [
             "base.userinfo_email",
             "base.userinfo_profile",
             "base.openid",
-            "chat.messages_readonly",
             "chat.messages",
             "chat.spaces",
-            "chat.memberships_readonly",
             "chat.memberships",
-            "people.readonly",
+            "people.contacts",
         ],
         # Bot identity scope (SA acts as Chat app — can send cards)
         "chat_bot": [
@@ -425,14 +419,13 @@ class ScopeRegistry:
             "base.userinfo_email",
             "base.openid",
             "forms.body",
-            "forms.body_readonly",
+            # No full scope covers form responses — this must stay.
             "forms.responses_readonly",
         ],
         "slides_basic": [
             "base.userinfo_email",
             "base.openid",
             "slides.full",
-            "slides.readonly",
         ],
         # Photos scopes CANNOT be combined with Drive (or other Workspace)
         # scopes in a single authorization request — Google's auth server
@@ -456,7 +449,6 @@ class ScopeRegistry:
         "tasks_basic": [
             "base.userinfo_email",
             "base.openid",
-            "tasks.readonly",
             "tasks.full",
         ],
         "tasks_full": ["base.userinfo_email", "base.openid", "tasks.full"],
@@ -464,8 +456,8 @@ class ScopeRegistry:
             "base.userinfo_email",
             "base.userinfo_profile",
             "base.openid",
-            "people.readonly",
-            "people.contacts",  # Write access needed for contact group management
+            "people.contacts",  # Full contacts covers readonly; write needed for contact groups
+            # No full scope covers directory data — this must stay.
             "people.directory_readonly",
         ],
         "people_full": [
@@ -479,7 +471,7 @@ class ScopeRegistry:
         "office_suite": [
             "base.userinfo_email",
             "base.openid",
-            "drive.file",
+            "drive.full",
             "docs.full",
             "sheets.full",
             "slides.full",
@@ -489,7 +481,7 @@ class ScopeRegistry:
             "base.openid",
             "gmail.modify",
             "chat.messages",
-            "calendar.events",
+            "calendar.full",
         ],
         "admin_suite": [
             "base.userinfo_email",
@@ -498,45 +490,39 @@ class ScopeRegistry:
             "admin.groups",
             "admin.roles",
         ],
-        # Comprehensive access for OAuth flows (validated scopes only)
+        # Comprehensive access for OAuth flows (validated scopes only).
+        #
+        # Least-privilege invariant (Google OAuth verification requires it):
+        # never request a narrower scope alongside the full scope that
+        # already covers it. Full scopes cover their readonly variants at
+        # the API level (drive ⊇ drive.readonly/drive.file, gmail.modify ⊇
+        # gmail.readonly/send/compose/labels, contacts ⊇ contacts.readonly,
+        # etc.), so the narrow strings here were redundant and Google's
+        # review flags such pairs. forms.responses_readonly and
+        # people.directory_readonly stay: no requested full scope covers
+        # form responses or directory data.
         "oauth_comprehensive": [
             "base.userinfo_email",
             "base.userinfo_profile",
             "base.openid",
             "drive.full",
-            "drive.readonly",
-            "drive.file",
-            "docs.readonly",
             "docs.full",
-            "gmail.readonly",
-            "gmail.send",
-            "gmail.compose",
             "gmail.modify",
-            "gmail.labels",
             "gmail.settings_basic",
             "gmail.settings_sharing",
-            "chat.messages_readonly",
             "chat.messages",
             "chat.spaces",
-            "chat.memberships_readonly",
             "chat.memberships",
-            "sheets.readonly",
             "sheets.full",
             "forms.body",
-            "forms.body_readonly",
             "forms.responses_readonly",
             "slides.full",
-            "slides.readonly",
             # photos.* intentionally excluded: Google rejects authorization
             # requests that combine photoslibrary scopes with Drive scopes
             # (400 invalid_request). Photos requires its own OAuth flow —
             # see SEPARATE_AUTH_SERVICES and the photos_basic group.
-            "calendar.readonly",
-            "calendar.events",
             "calendar.full",
-            "tasks.readonly",
             "tasks.full",
-            "people.readonly",
             "people.contacts",
             "people.directory_readonly",
         ],
@@ -683,19 +669,15 @@ class ScopeRegistry:
                 # If no full scope, add all available scopes
                 result_scopes.extend(service_scopes.values())
         else:
-            # Basic access - add commonly needed scopes
+            # Basic access — request the full scope where one exists (it
+            # covers readonly at the API level and keeps requests aligned
+            # with what the OAuth flows grant).
             if service == "drive":
-                result_scopes.extend(
-                    [service_scopes["file"], service_scopes["readonly"]]
-                )
+                result_scopes.append(service_scopes["full"])
             elif service == "gmail":
-                result_scopes.extend(
-                    [service_scopes["readonly"], service_scopes["send"]]
-                )
+                result_scopes.append(service_scopes["modify"])
             elif service == "calendar":
-                result_scopes.extend(
-                    [service_scopes["readonly"], service_scopes["events"]]
-                )
+                result_scopes.append(service_scopes["full"])
             elif service == "photos":
                 result_scopes.extend(
                     [
@@ -704,11 +686,11 @@ class ScopeRegistry:
                     ]
                 )
             else:
-                # Default to readonly and full if available
-                if "readonly" in service_scopes:
-                    result_scopes.append(service_scopes["readonly"])
+                # Default to the full scope, falling back to readonly
                 if "full" in service_scopes:
                     result_scopes.append(service_scopes["full"])
+                elif "readonly" in service_scopes:
+                    result_scopes.append(service_scopes["readonly"])
 
         return result_scopes
 

--- a/auth/scope_registry.py
+++ b/auth/scope_registry.py
@@ -356,10 +356,7 @@ class ScopeRegistry:
             "base.openid",
             "gmail.modify",
             "gmail.settings_basic",
-            # gmail.settings_sharing intentionally absent: only filter
-            # forward-to actions need it, and forwarding requires a
-            # pre-verified forwarding address anyway. Not requesting it
-            # keeps the restricted-scope surface minimal for verification.
+            "gmail.settings_sharing",
         ],
         "gmail_full": ["base.userinfo_email", "base.openid", "gmail.full"],
         "calendar_basic": [
@@ -498,7 +495,7 @@ class ScopeRegistry:
             "docs.full",
             "gmail.modify",
             "gmail.settings_basic",
-            # gmail.settings_sharing intentionally absent (see gmail_basic).
+            "gmail.settings_sharing",
             "chat.messages",
             "chat.spaces",
             "chat.memberships",

--- a/auth/scope_registry.py
+++ b/auth/scope_registry.py
@@ -356,7 +356,10 @@ class ScopeRegistry:
             "base.openid",
             "gmail.modify",
             "gmail.settings_basic",
-            "gmail.settings_sharing",
+            # gmail.settings_sharing intentionally absent: only filter
+            # forward-to actions need it, and forwarding requires a
+            # pre-verified forwarding address anyway. Not requesting it
+            # keeps the restricted-scope surface minimal for verification.
         ],
         "gmail_full": ["base.userinfo_email", "base.openid", "gmail.full"],
         "calendar_basic": [
@@ -495,7 +498,7 @@ class ScopeRegistry:
             "docs.full",
             "gmail.modify",
             "gmail.settings_basic",
-            "gmail.settings_sharing",
+            # gmail.settings_sharing intentionally absent (see gmail_basic).
             "chat.messages",
             "chat.spaces",
             "chat.memberships",

--- a/auth/scope_registry.py
+++ b/auth/scope_registry.py
@@ -316,18 +316,10 @@ class ScopeRegistry:
             documentation_url="https://developers.google.com/photos/library/reference",
             service_config={"service": "photoslibrary", "version": "v1"},
         ),
-        "tasks": ServiceMetadata(
-            name="Google Tasks",
-            description="Task management service",
-            icon="✅",
-            version="v1",
-            scopes=GOOGLE_API_SCOPES["tasks"],
-            default_scope_group="tasks_basic",
-            features=["task_lists", "due_dates", "notes", "completion_tracking"],
-            api_endpoint="https://tasks.googleapis.com/tasks/v1",
-            documentation_url="https://developers.google.com/tasks/reference",
-            service_config={"service": "tasks", "version": "v1"},
-        ),
+        # Google Tasks intentionally absent: no Tasks tools are implemented,
+        # and Google's OAuth verification requires every requested scope to
+        # map to a demonstrable feature. Re-add metadata + scope groups +
+        # oauth_comprehensive entry together with the first Tasks tool.
         "people": ServiceMetadata(
             name="Google People API",
             description="User profile and contact information service",
@@ -446,12 +438,6 @@ class ScopeRegistry:
             "photos.readonly_appcreated",
             "photos.edit_appcreated",
         ],
-        "tasks_basic": [
-            "base.userinfo_email",
-            "base.openid",
-            "tasks.full",
-        ],
-        "tasks_full": ["base.userinfo_email", "base.openid", "tasks.full"],
         "people_basic": [
             "base.userinfo_email",
             "base.userinfo_profile",
@@ -522,7 +508,6 @@ class ScopeRegistry:
             # (400 invalid_request). Photos requires its own OAuth flow —
             # see SEPARATE_AUTH_SERVICES and the photos_basic group.
             "calendar.full",
-            "tasks.full",
             "people.contacts",
             "people.directory_readonly",
         ],

--- a/auth/service_helpers.py
+++ b/auth/service_helpers.py
@@ -410,18 +410,6 @@ async def request_photos_service(scopes: Union[str, List[str]] = None) -> str:
     return await request_service("photos", scopes)
 
 
-async def get_tasks_service(
-    user_email: Optional[str] = None, scopes: Union[str, List[str]] = None
-) -> Any:
-    """Get Tasks service - supports both explicit and GoogleProvider auth."""
-    return await get_service("tasks", user_email, scopes)
-
-
-async def request_tasks_service(scopes: Union[str, List[str]] = None) -> str:
-    """Request Tasks service through middleware - convenience alias."""
-    return await request_service("tasks", scopes)
-
-
 # ============================================
 # Google API Resilience Helpers
 # ============================================

--- a/config/settings.py
+++ b/config/settings.py
@@ -751,56 +751,48 @@ class Settings(BaseSettings):
 
     # Legacy OAuth scopes - maintained for backward compatibility
     # These are now managed through the centralized scope registry
+    # Least-privilege set, kept in sync with the registry's
+    # oauth_comprehensive group: full scopes only — no redundant readonly/
+    # send/compose/labels variants (the full scope covers them at the API
+    # level, and Google's OAuth verification flags redundant pairs).
     _fallback_drive_scopes: list[str] = [
         # Base OAuth scopes for user identification
         "https://www.googleapis.com/auth/userinfo.email",
         "https://www.googleapis.com/auth/userinfo.profile",
         "openid",
-        # Google Drive scopes
+        # Google Drive
         "https://www.googleapis.com/auth/drive",
-        "https://www.googleapis.com/auth/drive.readonly",
-        "https://www.googleapis.com/auth/drive.file",
-        # Google Docs scopes
-        "https://www.googleapis.com/auth/documents.readonly",
+        # Google Docs
         "https://www.googleapis.com/auth/documents",
-        # Gmail API scopes
-        "https://www.googleapis.com/auth/gmail.readonly",
-        "https://www.googleapis.com/auth/gmail.send",
-        "https://www.googleapis.com/auth/gmail.compose",
+        # Gmail (modify covers read/send/compose/labels)
         "https://www.googleapis.com/auth/gmail.modify",
-        "https://www.googleapis.com/auth/gmail.labels",
         # Gmail Settings scopes (CRITICAL for filters/forwarding)
         "https://www.googleapis.com/auth/gmail.settings.basic",
         "https://www.googleapis.com/auth/gmail.settings.sharing",
-        # Google Chat API scopes
-        "https://www.googleapis.com/auth/chat.messages.readonly",
+        # Google Chat
         "https://www.googleapis.com/auth/chat.messages",
         "https://www.googleapis.com/auth/chat.spaces",
-        # Google Sheets API scopes
-        "https://www.googleapis.com/auth/spreadsheets.readonly",
+        "https://www.googleapis.com/auth/chat.memberships",
+        # Google Sheets
         "https://www.googleapis.com/auth/spreadsheets",
-        # Google Forms API scopes
+        # Google Forms (no full scope covers responses — responses.readonly stays)
         "https://www.googleapis.com/auth/forms.body",
-        "https://www.googleapis.com/auth/forms.body.readonly",
         "https://www.googleapis.com/auth/forms.responses.readonly",
-        # Google Slides API scopes
+        # Google Slides
         "https://www.googleapis.com/auth/presentations",
-        "https://www.googleapis.com/auth/presentations.readonly",
-        # Calendar scopes
-        "https://www.googleapis.com/auth/calendar.readonly",
-        "https://www.googleapis.com/auth/calendar.events",
+        # Calendar
         "https://www.googleapis.com/auth/calendar",
+        # Google Tasks
+        "https://www.googleapis.com/auth/tasks",
+        # People/Contacts (no full scope covers directory — directory.readonly stays)
+        "https://www.googleapis.com/auth/contacts",
+        "https://www.googleapis.com/auth/directory.readonly",
         # Google Photos Library API scopes intentionally excluded:
         # Google rejects authorization requests that combine photoslibrary
         # scopes with Drive scopes (400 invalid_request), and the broad
         # photoslibrary / photoslibrary.readonly / photoslibrary.sharing
         # scopes were retired after March 31, 2025. Photos must be
         # authorized via its own OAuth flow (selected_services=["photos"]).
-        # Cloud Platform scopes (for broader Google services)
-        "https://www.googleapis.com/auth/cloud-platform",
-        "https://www.googleapis.com/auth/cloudfunctions",
-        "https://www.googleapis.com/auth/pubsub",
-        "https://www.googleapis.com/auth/iam",
     ]
 
     @property

--- a/config/settings.py
+++ b/config/settings.py
@@ -766,9 +766,9 @@ class Settings(BaseSettings):
         "https://www.googleapis.com/auth/documents",
         # Gmail (modify covers read/send/compose/labels)
         "https://www.googleapis.com/auth/gmail.modify",
-        # Gmail Settings (filters/labels; settings.sharing intentionally
-        # absent — only filter forward-to actions need it)
+        # Gmail Settings scopes (CRITICAL for filters/forwarding)
         "https://www.googleapis.com/auth/gmail.settings.basic",
+        "https://www.googleapis.com/auth/gmail.settings.sharing",
         # Google Chat
         "https://www.googleapis.com/auth/chat.messages",
         "https://www.googleapis.com/auth/chat.spaces",
@@ -846,9 +846,16 @@ class Settings(BaseSettings):
             gmail_settings_basic = (
                 "https://www.googleapis.com/auth/gmail.settings.basic"
             )
+            gmail_settings_sharing = (
+                "https://www.googleapis.com/auth/gmail.settings.sharing"
+            )
             has_settings_basic = gmail_settings_basic in scopes
+            has_settings_sharing = gmail_settings_sharing in scopes
             logging.debug(
                 f"SCOPE_DEBUG: Gmail settings.basic included: {has_settings_basic}"
+            )
+            logging.debug(
+                f"SCOPE_DEBUG: Gmail settings.sharing included: {has_settings_sharing}"
             )
 
             return scopes

--- a/config/settings.py
+++ b/config/settings.py
@@ -782,8 +782,6 @@ class Settings(BaseSettings):
         "https://www.googleapis.com/auth/presentations",
         # Calendar
         "https://www.googleapis.com/auth/calendar",
-        # Google Tasks
-        "https://www.googleapis.com/auth/tasks",
         # People/Contacts (no full scope covers directory — directory.readonly stays)
         "https://www.googleapis.com/auth/contacts",
         "https://www.googleapis.com/auth/directory.readonly",

--- a/config/settings.py
+++ b/config/settings.py
@@ -766,9 +766,9 @@ class Settings(BaseSettings):
         "https://www.googleapis.com/auth/documents",
         # Gmail (modify covers read/send/compose/labels)
         "https://www.googleapis.com/auth/gmail.modify",
-        # Gmail Settings scopes (CRITICAL for filters/forwarding)
+        # Gmail Settings (filters/labels; settings.sharing intentionally
+        # absent — only filter forward-to actions need it)
         "https://www.googleapis.com/auth/gmail.settings.basic",
-        "https://www.googleapis.com/auth/gmail.settings.sharing",
         # Google Chat
         "https://www.googleapis.com/auth/chat.messages",
         "https://www.googleapis.com/auth/chat.spaces",
@@ -846,16 +846,9 @@ class Settings(BaseSettings):
             gmail_settings_basic = (
                 "https://www.googleapis.com/auth/gmail.settings.basic"
             )
-            gmail_settings_sharing = (
-                "https://www.googleapis.com/auth/gmail.settings.sharing"
-            )
             has_settings_basic = gmail_settings_basic in scopes
-            has_settings_sharing = gmail_settings_sharing in scopes
             logging.debug(
                 f"SCOPE_DEBUG: Gmail settings.basic included: {has_settings_basic}"
-            )
-            logging.debug(
-                f"SCOPE_DEBUG: Gmail settings.sharing included: {has_settings_sharing}"
             )
 
             return scopes

--- a/gmail/filters.py
+++ b/gmail/filters.py
@@ -576,20 +576,28 @@ async def create_gmail_filter(
         f"[create_gmail_filter] Parsed remove_label_ids: {parsed_remove_label_ids}"
     )
 
-    if parsed_add_label_ids:
-        action["addLabelIds"] = parsed_add_label_ids
-    if parsed_remove_label_ids:
-        action["removeLabelIds"] = parsed_remove_label_ids
+    # The Gmail API filter action only supports addLabelIds, removeLabelIds,
+    # and forward. The convenience booleans translate to system-label
+    # operations (the fields markAsImportant/markAsSpam/etc. do not exist in
+    # the API and were silently ignored, yielding "Filter doesn't have any
+    # actions" errors).
+    add_labels = list(parsed_add_label_ids or [])
+    remove_labels = list(parsed_remove_label_ids or [])
+    if mark_as_important:
+        add_labels.append("IMPORTANT")
+    if never_mark_as_important:
+        remove_labels.append("IMPORTANT")
+    if mark_as_spam:
+        add_labels.append("SPAM")
+    if never_mark_as_spam:
+        remove_labels.append("SPAM")
+
+    if add_labels:
+        action["addLabelIds"] = add_labels
+    if remove_labels:
+        action["removeLabelIds"] = remove_labels
     if forward_to:
         action["forward"] = forward_to
-    if mark_as_spam is not None:
-        action["markAsSpam"] = mark_as_spam
-    if mark_as_important is not None:
-        action["markAsImportant"] = mark_as_important
-    if never_mark_as_spam is not None:
-        action["neverMarkAsSpam"] = never_mark_as_spam
-    if never_mark_as_important is not None:
-        action["neverMarkAsImportant"] = never_mark_as_important
 
     # Validate that we have at least one criteria and one action
     if not criteria:

--- a/gmail/filters.py
+++ b/gmail/filters.py
@@ -726,10 +726,24 @@ async def create_gmail_filter(
         logger.error(f"Gmail API error in create_gmail_filter: {e}")
         error_msg = ""
         if e.resp.status in [401, 403]:
-            error_msg = "Authentication error: Please check your Gmail permissions and re-authenticate if necessary."
+            if forward_to:
+                error_msg = (
+                    f"Permission error creating a forwarding filter: forwarding requires the "
+                    f"gmail.settings.sharing scope. Re-authenticate with start_google_auth for "
+                    f"'{user_google_email}' to grant it, then retry."
+                )
+            else:
+                error_msg = "Authentication error: Please check your Gmail permissions and re-authenticate if necessary."
         elif e.resp.status == 400:
             error_details = str(e)
-            if "already exists" in error_details.lower():
+            if "unrecognized forwarding address" in error_details.lower():
+                error_msg = (
+                    f"Forwarding address not verified: '{forward_to}' is not set up as a "
+                    f"forwarding address for {user_google_email}. In Gmail, go to Settings → "
+                    f"'Forwarding and POP/IMAP' → 'Add a forwarding address', then click the "
+                    f"link in Google's confirmation email sent to that address. Retry once verified."
+                )
+            elif "already exists" in error_details.lower():
                 error_msg = "Filter already exists: A filter with similar criteria already exists in your Gmail account."
             elif "label" in error_details.lower() and (
                 "not found" in error_details.lower()

--- a/middleware/tag_based_resource_middleware.py
+++ b/middleware/tag_based_resource_middleware.py
@@ -238,16 +238,6 @@ class TagBasedResourceMiddleware(Middleware):
                         "id_field": "label",  # Changed from resourceName to match the tool parameter
                     }
                 }
-            elif service_name == "tasks":
-                service_config["list_types"] = {
-                    "task_lists": {
-                        "display_name": "Task Lists",
-                        "description": "Task lists and todo items",
-                        "list_tool": "list_task_lists",
-                        "get_tool": "get_task_list",
-                        "id_field": "task_list_id",
-                    }
-                }
 
             # Filter based on available tools if provided
             if available_tools:

--- a/people/people_tools.py
+++ b/people/people_tools.py
@@ -50,7 +50,7 @@ from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 from typing_extensions import Any, Dict, List, Optional, Union
 
-from auth.context import get_auth_middleware
+from auth.service_helpers import get_injected_service, request_service
 from config.enhanced_logging import setup_logger
 from tools.common_types import UserGoogleEmail
 
@@ -68,45 +68,40 @@ logger = setup_logger()
 
 async def _get_people_service(user_email: UserGoogleEmail):
     """
-    Build a Google People API service instance.
+    Get a People API service via middleware injection, falling back to
+    direct service creation (same pattern as the other service modules).
+
+    The previous implementation loaded credentials through
+    AuthMiddleware.load_credentials() without a decryption key, which
+    silently returns None under encrypted credential storage.
 
     Returns:
         A People API service client or None if credentials are unavailable.
     """
     if not user_email:
-        logger.warning("No user email provided for People API (contact labels listing)")
+        logger.warning("No user email provided for People API")
         return None
 
     try:
-        auth_middleware = get_auth_middleware()
-    except Exception as exc:
-        logger.warning(
-            f"AuthMiddleware lookup failed for People API (contact labels listing): {exc}"
-        )
-        return None
+        service_key = await request_service("people")
+        service = await get_injected_service(service_key)
+        if service:
+            logger.debug("Using middleware-injected People service")
+            return service
+    except Exception as e:
+        logger.warning(f"Middleware People service injection failed: {e}")
 
-    if not auth_middleware:
-        logger.warning(
-            "No AuthMiddleware available for People API (contact labels listing)"
-        )
-        return None
-
+    logger.info("Falling back to direct People service creation")
     try:
-        credentials = auth_middleware.load_credentials(user_email)
-    except Exception as exc:
-        logger.warning(
-            f"Error loading credentials for People API (contact labels listing) for user {user_email}: {exc}"
-        )
-        return None
+        from auth.scope_registry import ScopeRegistry
+        from auth.service_manager import get_google_service
 
-    if not credentials:
-        logger.warning(
-            f"No credentials found for People API (contact labels listing) for user {user_email}"
+        return await get_google_service(
+            user_email=user_email,
+            service_type="people",
+            version="v1",
+            scopes=ScopeRegistry.resolve_scope_group("people_basic"),
         )
-        return None
-
-    try:
-        return await asyncio.to_thread(build, "people", "v1", credentials=credentials)
     except Exception as exc:
         logger.error(f"Failed to build People API service: {exc}")
         return None

--- a/people/people_tools.py
+++ b/people/people_tools.py
@@ -47,6 +47,7 @@ import asyncio
 
 from fastmcp import FastMCP
 from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
 from typing_extensions import Any, Dict, List, Optional, Union
 
 from auth.context import get_auth_middleware
@@ -58,6 +59,8 @@ from .people_types import (
     GetPeopleContactGroupMembersResponse,
     ListPeopleContactLabelsResponse,
     ManagePeopleContactLabelsResponse,
+    PersonSearchResult,
+    SearchPeopleResponse,
 )
 
 logger = setup_logger()
@@ -694,8 +697,139 @@ async def list_people_contact_labels(
     )
 
 
+_PERSON_READ_MASK = "names,emailAddresses,phoneNumbers,organizations"
+
+
+def _person_to_result(person: Dict, source: str) -> PersonSearchResult:
+    """Convert a People API person object to a PersonSearchResult."""
+    names = person.get("names", [])
+    orgs = []
+    for org in person.get("organizations", []):
+        label = " @ ".join(p for p in [org.get("title"), org.get("name")] if p)
+        if label:
+            orgs.append(label)
+    return PersonSearchResult(
+        display_name=names[0].get("displayName") if names else None,
+        emails=[e["value"] for e in person.get("emailAddresses", []) if e.get("value")],
+        source=source,
+        resourceName=person.get("resourceName"),
+        organizations=orgs,
+        phones=[p["value"] for p in person.get("phoneNumbers", []) if p.get("value")],
+    )
+
+
+async def search_people(
+    query: str,
+    user_google_email: UserGoogleEmail = None,
+    page_size: int = 10,
+) -> SearchPeopleResponse:
+    """
+    Resolve a name (or partial name/email) to people, searching the user's
+    saved contacts (people.searchContacts, contacts scope) and — on Workspace
+    accounts — the organization directory (people.searchDirectoryPeople,
+    directory.readonly scope). Consumer Gmail accounts have no Workspace
+    directory; that source is skipped gracefully with an explanatory note.
+    """
+    service = await _get_people_service(user_google_email)
+    if service is None:
+        return SearchPeopleResponse(
+            success=False,
+            query=query,
+            user_email=user_google_email or "",
+            error="People API service unavailable - check credentials (run start_google_auth)",
+        )
+
+    results: List[PersonSearchResult] = []
+    directory_searched = False
+    directory_note: Optional[str] = None
+
+    # --- Source 1: saved contacts -------------------------------------------
+    try:
+        # Google recommends a warmup request (empty query) before the first
+        # searchContacts call so the search cache is populated.
+        await asyncio.to_thread(
+            service.people()
+            .searchContacts(query="", readMask=_PERSON_READ_MASK, pageSize=1)
+            .execute
+        )
+        contacts_resp = await asyncio.to_thread(
+            service.people()
+            .searchContacts(query=query, readMask=_PERSON_READ_MASK, pageSize=page_size)
+            .execute
+        )
+        for match in contacts_resp.get("results", []):
+            person = match.get("person")
+            if person:
+                results.append(_person_to_result(person, "contacts"))
+    except HttpError as e:
+        logger.error(f"search_people: contacts search failed: {e}")
+        return SearchPeopleResponse(
+            success=False,
+            query=query,
+            user_email=user_google_email or "",
+            error=f"Contacts search failed: {e}",
+        )
+
+    # --- Source 2: Workspace directory (org accounts only) ------------------
+    try:
+        directory_resp = await asyncio.to_thread(
+            service.people()
+            .searchDirectoryPeople(
+                query=query,
+                readMask=_PERSON_READ_MASK,
+                pageSize=page_size,
+                sources=[
+                    "DIRECTORY_SOURCE_TYPE_DOMAIN_PROFILE",
+                    "DIRECTORY_SOURCE_TYPE_DOMAIN_CONTACT",
+                ],
+            )
+            .execute
+        )
+        directory_searched = True
+        for person in directory_resp.get("people", []):
+            results.append(_person_to_result(person, "directory"))
+    except HttpError as e:
+        # Expected on consumer accounts: no Workspace directory exists.
+        status = e.resp.status if hasattr(e, "resp") else None
+        directory_note = (
+            "Workspace directory not available for this account "
+            "(consumer Gmail accounts have no org directory)."
+            if status in (400, 403)
+            else f"Directory search failed with HTTP {status}."
+        )
+        logger.info(f"search_people: directory source skipped: {directory_note}")
+
+    return SearchPeopleResponse(
+        success=True,
+        query=query,
+        results=results,
+        total_count=len(results),
+        contacts_searched=True,
+        directory_searched=directory_searched,
+        directory_note=directory_note,
+        user_email=user_google_email or "",
+    )
+
+
 def setup_people_tools(mcp: FastMCP) -> None:
     """Register People API tools with the FastMCP server."""
+
+    @mcp.tool(
+        name="search_people",
+        description=(
+            "Resolve a name to a person and their email address: search the user's "
+            "saved contacts and, on Workspace accounts, the organization directory. "
+            "Type 'Dan' and get matching people with their emails - useful before "
+            "sending mail, sharing files, or adding Chat members."
+        ),
+        tags={"people", "contacts", "directory", "search", "resolve", "service"},
+    )
+    async def search_people_tool(
+        query: str,
+        user_google_email: UserGoogleEmail = None,
+        page_size: int = 10,
+    ) -> SearchPeopleResponse:
+        return await search_people(query, user_google_email, page_size)
 
     @mcp.tool(
         name="list_people_contact_labels",

--- a/people/people_types.py
+++ b/people/people_types.py
@@ -79,6 +79,62 @@ class GetPeopleContactGroupMembersResponse(BaseModel):
 
 
 # =============================================================================
+# People Search Types
+# =============================================================================
+
+
+class PersonSearchResult(BaseModel):
+    """A single person matched by search_people."""
+
+    display_name: Optional[str] = Field(None, description="The person's display name")
+    emails: List[str] = Field(
+        default_factory=list, description="Email addresses for this person"
+    )
+    source: str = Field(
+        ...,
+        description="Where the match came from: 'contacts' (saved contacts) or 'directory' (Workspace org directory)",
+    )
+    resourceName: Optional[str] = Field(
+        None, description="People API resource name (e.g., 'people/c123')"
+    )
+    organizations: List[str] = Field(
+        default_factory=list,
+        description="Organization/title strings, when available (directory results)",
+    )
+    phones: List[str] = Field(
+        default_factory=list, description="Phone numbers, when available"
+    )
+
+
+class SearchPeopleResponse(BaseModel):
+    """Response structure for search_people tool."""
+
+    success: bool = Field(
+        True, description="Whether the operation completed successfully"
+    )
+    query: str = Field("", description="The search query that was executed")
+    results: List[PersonSearchResult] = Field(
+        default_factory=list, description="People matching the query, all sources"
+    )
+    total_count: int = Field(0, description="Total number of people returned")
+    contacts_searched: bool = Field(
+        True, description="Whether saved contacts were searched"
+    )
+    directory_searched: bool = Field(
+        False,
+        description="Whether the Workspace directory was searched successfully",
+    )
+    directory_note: Optional[str] = Field(
+        None,
+        description="Explanation when the directory source is unavailable (e.g., consumer Gmail accounts have no Workspace directory)",
+    )
+    user_email: str = Field(
+        "", description="Email address of the user who performed the search"
+    )
+    error: Optional[str] = Field(None, description="Error message if operation failed")
+
+
+# =============================================================================
 # Manage Contact Labels Types
 # =============================================================================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,13 +156,12 @@ python_classes = ["Test*"]
 python_functions = ["test_*"]
 addopts = "-v --tb=short --ignore=tests/content_mapping"
 asyncio_mode = "auto"
-# pytest-asyncio 1.x removed the custom event_loop fixture pattern; without
-# these, session/module-scoped async fixtures (e.g. the live MCP clients in
-# tests/client) are created on one event loop while each test runs on its own
-# function-scoped loop — the second call on a shared client then awaits a
-# connection owned by a foreign loop and hangs forever.
-asyncio_default_fixture_loop_scope = "session"
-asyncio_default_test_loop_scope = "session"
+# NOTE: do NOT set asyncio_default_*_loop_scope = "session" here. The unit
+# suite has tests that close or replace the running event loop; under a
+# shared session loop that kills every async test after them (CI: "There is
+# no current event loop"). The client suite, which DOES need session-scoped
+# loops for its shared live-server clients, gets them from
+# tests/client/pytest.ini — the active config when running `pytest tests/client/`.
 
 markers = [
     "auth_required: mark test as requiring authentication",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "google-workspace-unlimited"
-version = "2.7.0"
+version = "2.8.0"
 description = "Comprehensive MCP server for Google Workspace integration - 90+ tools across Gmail, Drive, Docs, Sheets, Slides, Calendar, Forms, Chat, and Photos with Code Mode tool discovery and OAuth 2.1 + PKCE authentication"
 readme = "README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,6 +156,13 @@ python_classes = ["Test*"]
 python_functions = ["test_*"]
 addopts = "-v --tb=short --ignore=tests/content_mapping"
 asyncio_mode = "auto"
+# pytest-asyncio 1.x removed the custom event_loop fixture pattern; without
+# these, session/module-scoped async fixtures (e.g. the live MCP clients in
+# tests/client) are created on one event loop while each test runs on its own
+# function-scoped loop — the second call on a shared client then awaits a
+# connection owned by a foreign loop and hangs forever.
+asyncio_default_fixture_loop_scope = "session"
+asyncio_default_test_loop_scope = "session"
 
 markers = [
     "auth_required: mark test as requiring authentication",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "google-workspace-unlimited"
 version = "2.8.0"
-description = "Comprehensive MCP server for Google Workspace integration - 90+ tools across Gmail, Drive, Docs, Sheets, Slides, Calendar, Forms, Chat, and Photos with Code Mode tool discovery and OAuth 2.1 + PKCE authentication"
+description = "Comprehensive MCP server for Google Workspace integration - 90+ tools across Gmail, Drive, Docs, Sheets, Slides, Calendar, Forms, Chat, Photos, and Contacts with Code Mode tool discovery and OAuth 2.1 + PKCE authentication"
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.11,<3.13"

--- a/sheets/sheets_tools.py
+++ b/sheets/sheets_tools.py
@@ -169,14 +169,12 @@ async def _get_sheets_service_with_fallback(user_google_email: str):
         shim = CompatibilityShim()
         sheets_scopes = [
             shim.get_legacy_scope_groups()["sheets_write"],
-            shim.get_legacy_scope_groups()["sheets_read"],
         ]
     except Exception as e:
         logger.warning(f"Failed to get sheets scopes from compatibility shim: {e}")
         # Fallback to hardcoded scopes
         sheets_scopes = [
             "https://www.googleapis.com/auth/spreadsheets",
-            "https://www.googleapis.com/auth/spreadsheets.readonly",
         ]
 
     return await get_google_service(

--- a/tests/client/conftest.py
+++ b/tests/client/conftest.py
@@ -323,17 +323,10 @@ def pytest_configure(config):
     )
 
 
-@pytest.fixture(scope="session")
-def event_loop():
-    """Create a session-scoped event loop for async fixtures.
-
-    This is required for session-scoped async fixtures to work properly
-    with pytest-asyncio. Without this, session-scoped async fixtures
-    will hang because they try to use a function-scoped event loop.
-    """
-    loop = asyncio.new_event_loop()
-    yield loop
-    loop.close()
+# NOTE: no custom `event_loop` fixture here — pytest-asyncio 1.x removed
+# support for overriding it. Loop sharing is configured instead via
+# asyncio_default_fixture_loop_scope / asyncio_default_test_loop_scope
+# (see pyproject.toml [tool.pytest.ini_options] and tests/client/pytest.ini).
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/client/pytest.ini
+++ b/tests/client/pytest.ini
@@ -1,4 +1,6 @@
-[tool:pytest]
+[pytest]
+# NOTE: the section header must be [pytest] in a pytest.ini file —
+# [tool:pytest] is the setup.cfg form and makes pytest ignore the file.
 # Pytest configuration for client tests
 testpaths = tests/client
 python_files = test_*.py
@@ -7,8 +9,10 @@ python_functions = test_*
 
 # Asyncio configuration
 asyncio_mode = auto
-# Session-scoped fixtures need session-scoped event loop
+# Session-scoped fixtures need session-scoped event loop — and tests must
+# run on that same loop, or calls on shared clients hang cross-loop.
 asyncio_default_fixture_loop_scope = session
+asyncio_default_test_loop_scope = session
 
 # Markers for test organization
 markers =
@@ -21,6 +25,8 @@ markers =
     security: Security validation tests for access control
     x402: x402 payment protocol tests (requires TEST_CLIENT_PK)
     payment: Payment-related tests
+    core: Core tests
+    order(n): Ordering hint
 
 # Test output configuration
 addopts = 

--- a/tests/client/test_calendar_tools.py
+++ b/tests/client/test_calendar_tools.py
@@ -214,43 +214,24 @@ class TestCalendarTools:
 
     @pytest.mark.asyncio
     async def test_list_events_structured_error_response(self, client):
-        """Test that list_events returns structured responses even on errors."""
-        # Use an invalid calendar ID to trigger an error
-        result = await client.call_tool(
-            "list_events",
-            {
-                "user_google_email": "nonexistent@invalid.com",
-                "calendar_id": "invalid_calendar_id",
-                "max_results": 5,
-            },
-        )
+        """Calling with a foreign email is rejected by the identity middleware.
 
-        # Handle CallToolResult object properly
-        assert result is not None
-        # Extract content from result
-        if hasattr(result, "content"):
-            if isinstance(result.content, list) and len(result.content) > 0:
-                content = (
-                    result.content[0].text
-                    if hasattr(result.content[0], "text")
-                    else str(result.content[0])
-                )
-            else:
-                content = str(result.content) if result.content else ""
-        else:
-            content = str(result)
+        The session-email mismatch guard rejects calls whose
+        user_google_email doesn't match the authenticated session before
+        the tool runs, so this surfaces as a ToolError — not a structured
+        error payload from the tool itself.
+        """
+        from fastmcp.exceptions import ToolError
 
-        # The error should be returned as structured content, not a raw error string
-        # Check that we don't get the old ValueError about structured_content
-        assert "ValueError: structured_content must be a dict or None" not in content, (
-            "Bug detected: Error responses are not being returned as structured EventListResponse"
-        )
-
-        # The response should contain error information
-        assert any(
-            keyword in content.lower()
-            for keyword in ["error", "failed", "unable", "requires authentication"]
-        ), f"Error response not properly formatted: {content}"
+        with pytest.raises(ToolError, match="[Ee]mail mismatch"):
+            await client.call_tool(
+                "list_events",
+                {
+                    "user_google_email": "nonexistent@invalid.com",
+                    "calendar_id": "invalid_calendar_id",
+                    "max_results": 5,
+                },
+            )
 
     @pytest.mark.asyncio
     async def test_list_events_with_time_range(self, client):
@@ -1362,38 +1343,17 @@ class TestCalendarTools:
 
     @pytest.mark.asyncio
     async def test_list_calendars_structured_error_response(self, client):
-        """Test that list_calendars returns structured responses even on errors."""
-        # Use an invalid email to trigger an error
-        result = await client.call_tool(
-            "list_calendars", {"user_google_email": "nonexistent@invalid.com"}
-        )
+        """Calling with a foreign email is rejected by the identity middleware.
 
-        # Handle CallToolResult object properly
-        assert result is not None
-        # Extract content from result
-        if hasattr(result, "content"):
-            if isinstance(result.content, list) and len(result.content) > 0:
-                content = (
-                    result.content[0].text
-                    if hasattr(result.content[0], "text")
-                    else str(result.content[0])
-                )
-            else:
-                content = str(result.content) if result.content else ""
-        else:
-            content = str(result)
+        See test_list_events_structured_error_response — the mismatch guard
+        raises ToolError before the tool produces a structured response.
+        """
+        from fastmcp.exceptions import ToolError
 
-        # The error should be returned as structured content, not a raw error string
-        # Check that we don't get the old ValueError about structured_content
-        assert "ValueError: structured_content must be a dict or None" not in content, (
-            "Bug detected: Error responses are not being returned as structured CalendarListResponse"
-        )
-
-        # The response should contain error information
-        assert any(
-            keyword in content.lower()
-            for keyword in ["error", "failed", "unable", "requires authentication"]
-        ), f"Error response not properly formatted: {content}"
+        with pytest.raises(ToolError, match="[Ee]mail mismatch"):
+            await client.call_tool(
+                "list_calendars", {"user_google_email": "nonexistent@invalid.com"}
+            )
 
 
 @pytest.mark.service("calendar")

--- a/tests/client/test_code_mode_integration.py
+++ b/tests/client/test_code_mode_integration.py
@@ -118,7 +118,8 @@ class TestJsonIntegration:
             exec_client,
             "d = {'a': 1, 'b': [1, 2, 3]}\nreturn from_json(to_json(d)) == d",
         )
-        assert "True" in out
+        # execute JSON-serialises return values, so a bool renders as "true"
+        assert out.strip().lower() in ("true", '"true"') or "True" in out
 
     async def test_from_json_passthrough(self, exec_client):
         out = await run(
@@ -316,51 +317,35 @@ class TestHashIntegration:
 
 @pytest.mark.asyncio
 class TestSandboxBehaviours:
-    async def test_starred_list_returns_sandbox_error(self, exec_client):
-        """[*a, *b] fails at Monty PARSE TIME — not catchable inside the code.
+    async def test_starred_list_unpacking_works(self, exec_client):
+        """[*a, *b] parses and evaluates.
 
-        WRONG approach (what we originally tested):
-            try:
-                r = [*a, *b]       # ← inside the code passed to Monty
-            except Exception as e:
-                return str(e)      # ← this never runs; parser rejects the whole file
-
-        CORRECT expectation after fix: execute returns "SandboxError: ..." as text,
-        the tool call does NOT raise an MCP-level exception.
+        Historically pydantic-monty rejected starred expressions at parse
+        time (the whole block failed with SandboxError before any line ran).
+        Current Monty supports them — keep this pinned so a regression to
+        the old parse-time failure is caught.
         """
-        out = await run(exec_client, "a = [1, 2]\nb = [3, 4]\nreturn [*a, *b]")
-        assert "SandboxError" in out, (
-            f"Expected SandboxError in output, got: {out!r}\n"
-            "If this test raises instead of returning, run() is not catching parse errors."
-        )
-        assert "starred" in out.lower() or "a + b" in out
+        out = await run(exec_client, "a = [1, 2]\nb = [3, 4]\nreturn to_json([*a, *b])")
+        assert json.loads(out) == [1, 2, 3, 4]
 
-    async def test_starred_dict_returns_sandbox_error(self, exec_client):
-        """{**d1, **d2} also fails at parse time."""
+    async def test_starred_dict_unpacking_works(self, exec_client):
+        """{**d1, **d2} parses and evaluates (see starred-list note above)."""
         out = await run(
-            exec_client, "d1 = {'a': 1}\nd2 = {'b': 2}\nreturn {**d1, **d2}"
+            exec_client, "d1 = {'a': 1}\nd2 = {'b': 2}\nreturn to_json({**d1, **d2})"
         )
-        assert "SandboxError" in out
+        assert json.loads(out) == {"a": 1, "b": 2}
 
-    async def test_starred_in_try_except_is_still_parse_error(self, exec_client):
-        """Wrapping [*a, *b] in try/except inside the code does NOT help.
-
-        The parser sees [*a, *b] and rejects the whole file before any
-        try/except can execute.  After the fix, run() catches it externally
-        and the output is SandboxError — NOT 'caught: ...'.
-        """
+    async def test_starred_inside_try_except_works(self, exec_client):
+        """Starred expressions inside try/except evaluate normally now."""
         code = (
             "a = [1]\nb = [2]\n"
             "try:\n"
-            "  r = [*a, *b]\n"
+            "  return to_json([*a, *b])\n"
             "except Exception as e:\n"
             "  return 'caught: ' + str(e)"
         )
         out = await run(exec_client, code)
-        assert "caught:" not in out, (
-            "try/except inside Monty code cannot catch parse-time failures"
-        )
-        assert "SandboxError" in out
+        assert json.loads(out) == [1, 2]
 
     async def test_sorted_lambda_key_returns_error(self, exec_client):
         """sorted_(items, key=lambda x: x['n']) causes TypeError at runtime.
@@ -415,9 +400,11 @@ class TestSandboxBehaviours:
         assert "subprocess" in out.lower() or "module" in out.lower()
 
     async def test_return_required_for_output(self, exec_client):
-        """Without return, execute produces no meaningful output."""
-        out = await run(exec_client, "x = 42")
-        assert out.strip() in ("", "None", "null")
+        """Without return, execute produces no output content at all."""
+        result = await exec_client.call_tool("execute", {"code": "x = 42"})
+        assert not result.is_error
+        text = result.content[0].text if result.content else ""
+        assert text.strip() in ("", "None", "null")
 
     async def test_multiline_computation(self, exec_client):
         """Complex multi-step logic works end-to-end."""

--- a/tests/client/test_mcp_client.py
+++ b/tests/client/test_mcp_client.py
@@ -22,9 +22,10 @@ class TestMCPServer:
     async def test_list_tools(self, client):
         """Test listing available tools.
 
-        NOTE: When CodeMode is enabled, list_tools returns 4 meta-tools
-        (tags, search, get_schema, execute) instead of individual tools.
-        Underlying tools are accessed via the `execute` meta-tool.
+        NOTE: When CodeMode is enabled, list_tools returns only meta-tools
+        (tags, search, get_schema, execute, plus optional extras like
+        semantic_search, fetch_document, tool_activity) instead of
+        individual tools. Underlying tools are accessed via `execute`.
         """
         tools = await client.list_tools()
 
@@ -33,13 +34,17 @@ class TestMCPServer:
 
         tool_names = [tool.name for tool in tools]
 
-        # Detect CodeMode (4 meta-tools) vs normal mode
+        # Detect CodeMode (meta-tools only) vs normal mode
         code_mode_tools = {"tags", "search", "get_schema", "execute"}
         if code_mode_tools.issubset(set(tool_names)):
-            # CodeMode is active — verify the 4 meta-tools
-            assert len(tool_names) == 4, (
-                f"CodeMode should expose exactly 4 meta-tools, got {len(tool_names)}: {tool_names}"
+            # CodeMode is active — only meta-tools are exposed, and the
+            # exact set can grow (semantic_search, fetch_document, ...).
+            # The real signal is that individual service tools are hidden.
+            assert len(tool_names) <= 10, (
+                f"CodeMode should expose only meta-tools, got {len(tool_names)}: {tool_names}"
             )
+            assert "send_gmail_message" not in tool_names
+            assert "search_drive_files" not in tool_names
         else:
             # Normal mode — check for expected tools
             assert "health_check" in tool_names

--- a/tests/data/tool_schema_snapshot.json
+++ b/tests/data/tool_schema_snapshot.json
@@ -580,6 +580,11 @@
     "space_id",
     "user_google_email"
   ],
+  "search_people": [
+    "page_size",
+    "query",
+    "user_google_email"
+  ],
   "search_photos": [
     "album_id",
     "content_categories",

--- a/tests/data/tool_schema_snapshot.json
+++ b/tests/data/tool_schema_snapshot.json
@@ -399,7 +399,8 @@
   "manage_credentials": [
     "action",
     "email",
-    "new_storage_mode"
+    "new_storage_mode",
+    "user_google_email"
   ],
   "manage_drive_files": [
     "file_ids",

--- a/tests/test_scope_least_privilege.py
+++ b/tests/test_scope_least_privilege.py
@@ -1,0 +1,160 @@
+"""
+Least-privilege scope invariants for Google OAuth verification.
+
+Google's verification review requires (a) the app to request only the
+narrowest scopes needed, flagging redundant narrow+full pairs of the
+same resource, and (b) every scope a tool requests to be granted by an
+OAuth flow, so Cloud Console / consent screen / API traffic all match.
+
+These tests are pure registry logic and run in every environment.
+"""
+
+import pytest
+
+from auth.scope_registry import ScopeRegistry
+
+# For each full scope the app requests, the narrower scopes it covers at
+# the API level. Requesting both is redundant and Google flags it.
+REDUNDANT_UNDER_FULL = {
+    "https://www.googleapis.com/auth/drive": [
+        "https://www.googleapis.com/auth/drive.readonly",
+        "https://www.googleapis.com/auth/drive.file",
+    ],
+    "https://www.googleapis.com/auth/gmail.modify": [
+        "https://www.googleapis.com/auth/gmail.readonly",
+        "https://www.googleapis.com/auth/gmail.send",
+        "https://www.googleapis.com/auth/gmail.compose",
+        "https://www.googleapis.com/auth/gmail.labels",
+    ],
+    "https://www.googleapis.com/auth/calendar": [
+        "https://www.googleapis.com/auth/calendar.readonly",
+        "https://www.googleapis.com/auth/calendar.events",
+    ],
+    "https://www.googleapis.com/auth/documents": [
+        "https://www.googleapis.com/auth/documents.readonly",
+    ],
+    "https://www.googleapis.com/auth/spreadsheets": [
+        "https://www.googleapis.com/auth/spreadsheets.readonly",
+    ],
+    "https://www.googleapis.com/auth/presentations": [
+        "https://www.googleapis.com/auth/presentations.readonly",
+    ],
+    "https://www.googleapis.com/auth/forms.body": [
+        "https://www.googleapis.com/auth/forms.body.readonly",
+    ],
+    "https://www.googleapis.com/auth/tasks": [
+        "https://www.googleapis.com/auth/tasks.readonly",
+    ],
+    "https://www.googleapis.com/auth/contacts": [
+        "https://www.googleapis.com/auth/contacts.readonly",
+    ],
+    "https://www.googleapis.com/auth/chat.messages": [
+        "https://www.googleapis.com/auth/chat.messages.readonly",
+    ],
+    "https://www.googleapis.com/auth/chat.memberships": [
+        "https://www.googleapis.com/auth/chat.memberships.readonly",
+    ],
+}
+
+# Narrow scopes that MUST stay: no requested full scope covers them.
+REQUIRED_NARROW_SCOPES = {
+    "https://www.googleapis.com/auth/forms.responses.readonly",
+    "https://www.googleapis.com/auth/directory.readonly",
+}
+
+# Scope groups used only by the Chat service account (domain-wide
+# delegation / app identity), not by the user OAuth consent flow.
+SERVICE_ACCOUNT_GROUPS = {"chat_bot", "chat_app", "admin_suite"}
+
+
+def _granted_workspace_scopes() -> set:
+    return set(ScopeRegistry.resolve_scope_group("oauth_comprehensive"))
+
+
+def _granted_photos_scopes() -> set:
+    return set(ScopeRegistry.resolve_scope_group("photos_basic"))
+
+
+class TestNoRedundantScopePairs:
+    def test_oauth_comprehensive_has_no_redundant_pairs(self):
+        granted = _granted_workspace_scopes()
+        for full, narrows in REDUNDANT_UNDER_FULL.items():
+            if full in granted:
+                overlap = granted & set(narrows)
+                assert not overlap, (
+                    f"oauth_comprehensive requests {sorted(overlap)} alongside "
+                    f"{full}, which already covers them — Google's verification "
+                    f"flags redundant narrow+full pairs"
+                )
+
+    def test_required_narrow_scopes_survive_the_trim(self):
+        granted = _granted_workspace_scopes()
+        missing = REQUIRED_NARROW_SCOPES - granted
+        assert not missing, (
+            f"These scopes have no covering full scope and must stay: {missing}"
+        )
+
+    def test_photos_flow_untouched(self):
+        assert _granted_photos_scopes() >= {
+            "https://www.googleapis.com/auth/photoslibrary.appendonly",
+            "https://www.googleapis.com/auth/photoslibrary.readonly.appcreateddata",
+            "https://www.googleapis.com/auth/photoslibrary.edit.appcreateddata",
+        }
+
+
+class TestRequestedScopesAreGranted:
+    """Every scope tools request by default must be granted by an OAuth flow.
+
+    Otherwise service requests log 'missing scopes' warnings and the
+    consent screen / Cloud Console / API traffic drift apart — the exact
+    mismatch Google's verification review rejects.
+    """
+
+    def test_service_defaults_are_subset_of_granted(self):
+        granted = _granted_workspace_scopes() | _granted_photos_scopes()
+        for service in ScopeRegistry.SERVICE_METADATA:
+            if service in ScopeRegistry.SEPARATE_AUTH_SERVICES:
+                requested = set(ScopeRegistry.get_service_scopes(service, "basic"))
+                extra = requested - _granted_photos_scopes()
+            else:
+                requested = set(ScopeRegistry.get_service_scopes(service, "basic"))
+                extra = requested - granted
+            assert not extra, (
+                f"Service '{service}' requests scopes no OAuth flow grants: "
+                f"{sorted(extra)}"
+            )
+
+    def test_user_scope_groups_are_subset_of_granted(self):
+        granted = _granted_workspace_scopes() | _granted_photos_scopes()
+        skip = SERVICE_ACCOUNT_GROUPS | {"oauth_comprehensive"}
+        failures = {}
+        for group in ScopeRegistry.SERVICE_SCOPE_GROUPS:
+            if group in skip or group.endswith("_full"):
+                continue
+            extra = set(ScopeRegistry.resolve_scope_group(group)) - granted
+            if extra:
+                failures[group] = sorted(extra)
+        assert not failures, (
+            f"User-flow scope groups request scopes no OAuth flow grants: {failures}"
+        )
+
+    def test_settings_fallback_matches_registry(self):
+        from config.settings import settings
+
+        fallback = set(settings._fallback_drive_scopes)
+        registry = _granted_workspace_scopes()
+        assert fallback == registry, (
+            "settings._fallback_drive_scopes drifted from the registry's "
+            f"oauth_comprehensive group. Only in fallback: "
+            f"{sorted(fallback - registry)}; only in registry: "
+            f"{sorted(registry - fallback)}"
+        )
+
+    def test_dcr_defaults_are_subset_of_granted(self):
+        from auth.compatibility_shim import CompatibilityShim
+
+        dcr = set(CompatibilityShim.get_legacy_dcr_scope_defaults().split())
+        assert dcr <= _granted_workspace_scopes(), (
+            f"DCR default scopes not granted by the Workspace flow: "
+            f"{sorted(dcr - _granted_workspace_scopes())}"
+        )

--- a/tests/test_search_people.py
+++ b/tests/test_search_people.py
@@ -1,0 +1,104 @@
+"""
+Tests for the search_people tool (name -> person/email resolution).
+
+search_people is the demonstrable feature behind the contacts and
+directory.readonly scopes: it searches saved contacts via
+people.searchContacts and the Workspace org directory via
+people.searchDirectoryPeople, skipping the directory gracefully on
+consumer accounts (which have none).
+
+These tests mock the People API service, so they run in every environment.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from googleapiclient.errors import HttpError
+
+from people.people_tools import search_people
+
+CONTACT = {
+    "resourceName": "people/c1",
+    "names": [{"displayName": "Dan Edelstein"}],
+    "emailAddresses": [{"value": "dedelste88@gmail.com"}],
+}
+DIRECTORY_PERSON = {
+    "resourceName": "people/d1",
+    "names": [{"displayName": "Dana Rivers"}],
+    "emailAddresses": [{"value": "dana@riversunlimited.xyz"}],
+    "organizations": [{"title": "Engineer", "name": "Rivers Unlimited"}],
+}
+
+
+def _http_error(status: int) -> HttpError:
+    resp = MagicMock()
+    resp.status = status
+    resp.reason = "error"
+    return HttpError(resp=resp, content=b"error")
+
+
+@pytest.fixture
+def people_service():
+    service = MagicMock()
+    with patch("people.people_tools._get_people_service", return_value=service):
+        yield service
+
+
+async def test_resolves_name_to_contact_email(people_service):
+    people_service.people().searchContacts().execute.return_value = {
+        "results": [{"person": CONTACT}]
+    }
+    people_service.people().searchDirectoryPeople().execute.side_effect = _http_error(
+        403
+    )
+
+    result = await search_people("Dan", user_google_email="user@example.com")
+
+    assert result.success is True
+    assert result.total_count == 1
+    match = result.results[0]
+    assert match.display_name == "Dan Edelstein"
+    assert match.emails == ["dedelste88@gmail.com"]
+    assert match.source == "contacts"
+
+
+async def test_directory_results_merge_on_workspace_accounts(people_service):
+    people_service.people().searchContacts().execute.return_value = {"results": []}
+    people_service.people().searchDirectoryPeople().execute.return_value = {
+        "people": [DIRECTORY_PERSON]
+    }
+
+    result = await search_people("Dana", user_google_email="user@example.com")
+
+    assert result.success is True
+    assert result.directory_searched is True
+    assert result.directory_note is None
+    match = result.results[0]
+    assert match.source == "directory"
+    assert match.emails == ["dana@riversunlimited.xyz"]
+    assert match.organizations == ["Engineer @ Rivers Unlimited"]
+
+
+async def test_consumer_account_skips_directory_gracefully(people_service):
+    people_service.people().searchContacts().execute.return_value = {
+        "results": [{"person": CONTACT}]
+    }
+    people_service.people().searchDirectoryPeople().execute.side_effect = _http_error(
+        403
+    )
+
+    result = await search_people("Dan", user_google_email="user@example.com")
+
+    assert result.success is True
+    assert result.directory_searched is False
+    assert "consumer" in (result.directory_note or "").lower()
+    assert result.total_count == 1
+
+
+async def test_contacts_failure_reports_error(people_service):
+    people_service.people().searchContacts().execute.side_effect = _http_error(500)
+
+    result = await search_people("Dan", user_google_email="user@example.com")
+
+    assert result.success is False
+    assert result.error is not None

--- a/tools/server_tools.py
+++ b/tools/server_tools.py
@@ -639,13 +639,24 @@ def setup_server_tools(mcp: FastMCP) -> None:
         },
     )
     async def manage_credentials_tool(
-        email: Annotated[str, Field(description="User's Google email address")],
         action: Annotated[
             Literal["status", "migrate", "summary", "delete"],
             Field(
                 description="Action to perform: 'status' (check status), 'migrate' (migrate storage mode), 'summary' (get summary), 'delete' (delete credentials)"
             ),
         ],
+        email: Annotated[
+            Optional[str],
+            Field(
+                description="Target user's Google email address. Takes precedence over user_google_email when both are set."
+            ),
+        ] = None,
+        user_google_email: Annotated[
+            Optional[str],
+            Field(
+                description="Session user's Google email (auto-injected by middleware). Used as the target when 'email' is not given."
+            ),
+        ] = None,
         new_storage_mode: Annotated[
             Optional[str],
             Field(
@@ -656,15 +667,30 @@ def setup_server_tools(mcp: FastMCP) -> None:
         """
         Manage credential storage and security settings.
 
+        The target account is `email` when provided, otherwise the
+        session's auto-injected `user_google_email` — so the tool works
+        both with an explicit target and through code-mode execute,
+        whose middleware injects user_google_email into every call.
+
         Args:
-            email: User's Google email address
             action: Action to perform - 'status', 'migrate', 'summary', or 'delete'
+            email: Explicit target email (wins over user_google_email)
+            user_google_email: Session email fallback (auto-injected)
             new_storage_mode: Target storage mode for migration (required when action='migrate')
 
         Returns:
             ManageCredentialsResponse: Structured result of the credential management operation
         """
-        return await manage_credentials(email, action, new_storage_mode)
+        target_email = email or user_google_email
+        if not target_email:
+            return ManageCredentialsResponse(
+                success=False,
+                action=action,
+                email="",
+                message="No target account: provide 'email' (or authenticate so user_google_email is injected).",
+                error="Missing email",
+            )
+        return await manage_credentials(target_email, action, new_storage_mode)
 
     @mcp.tool(
         name="manage_tools",

--- a/uv.lock
+++ b/uv.lock
@@ -1165,7 +1165,7 @@ wheels = [
 
 [[package]]
 name = "google-workspace-unlimited"
-version = "2.7.0"
+version = "2.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiodebug" },


### PR DESCRIPTION
## Why

Google's verification review flagged the app for requesting ~32 scopes while the Console submission listed fewer, and their least-privilege policy rejects requesting a narrow scope alongside the full scope that already covers it (the exact objection from the earlier Photos round, times eleven). This PR trims the Workspace OAuth flow to the minimum set with **zero capability loss**.

## What

**`oauth_comprehensive`: 32 → 16 API scopes.** Full scopes cover their narrower variants at the API level:

| Kept | Cut (covered by kept) |
|---|---|
| `drive` | `drive.readonly`, `drive.file` |
| `gmail.modify` | `gmail.readonly`, `gmail.send`, `gmail.compose`, `gmail.labels` |
| `calendar` | `calendar.readonly`, `calendar.events` |
| `documents` / `spreadsheets` / `presentations` / `forms.body` / `tasks` / `contacts` / `chat.messages` / `chat.memberships` | their `.readonly` variants |

**Kept deliberately** (no full scope covers them): `forms.responses.readonly`, `directory.readonly`. **Photos flow untouched** (3 granular scopes, separate auth).

**Aligned in the same pass** so every scope tools request stays a subset of what the flows grant: per-service `*_basic` groups, `get_service_scopes` hardcoded fallbacks, DCR defaults, OAuth-metadata fallback, sheets fallback shim, `settings._fallback_drive_scopes`.

**No re-auth required:** existing tokens hold a superset of the new request set; scope validation is warn-only throughout (audited all four check sites).

## New invariant tests

`tests/test_scope_least_privilege.py` (7 tests) locks: no redundant narrow+full pairs; required narrow scopes present; every service default and user scope group ⊆ granted set; settings fallback == registry; DCR defaults ⊆ granted. Future scope drift fails CI.

## Verification

- Full suite matches unmodified main exactly (530 passed; the 1 failure is a pre-existing order-dependent test, fails identically on main).
- Generated the **real authorization URLs** through the app code: Workspace flow requests exactly the 16 + 3 identity scopes, Photos flow exactly its 3 granular scopes.
- Server boots clean on :8002 with the trim; `ruff check .` + `ruff format --check .` clean.
- Client test suite run against the live local server in progress — results will be posted as a PR comment.

## Release

Version 2.7.0 → 2.8.0 (behavior-default change) in `pyproject.toml` + `uv.lock`.

## After merge (OAuth verification checklist)

1. Cloud Console Data Access = these 16 scopes + 3 Photos scopes, nothing else.
2. Re-record the demo showing the new consent screen (no readonly duplicates) and a feature per scope.
3. Reply to Google's verification email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)