### PR TITLE
Release 2.11.0 — accept MCP API key via X-API-Key header; FastMCP 3.4.7

### DIFF
--- a/auth/api_key_header_middleware.py
+++ b/auth/api_key_header_middleware.py
@@ -1,0 +1,70 @@
+"""ASGI middleware: accept the per-user MCP API key via an ``X-API-Key`` header.
+
+Some MCP clients (e.g. Claude Desktop's custom-connector UI) only allow an
+approved list of custom header names and do not let users set
+``Authorization`` directly. This middleware lets those clients send the minted
+key in an alternate header; it is rewritten to ``Authorization: Bearer <key>``
+before the request reaches FastMCP's bearer auth, so every existing auth path
+keeps working unchanged.
+
+Accepted header names (first match wins), overridable via the
+``MCP_API_KEY_HEADERS`` env var (comma-separated):
+
+    x-api-key, x-apikey, x-api-token, x-auth-token, x-access-token, x-token
+
+An existing ``Authorization`` header always takes precedence.
+"""
+
+from __future__ import annotations
+
+import os
+
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+DEFAULT_API_KEY_HEADERS = (
+    "x-api-key",
+    "x-apikey",
+    "x-api-token",
+    "x-auth-token",
+    "x-access-token",
+    "x-token",
+)
+
+
+def _configured_headers() -> tuple[bytes, ...]:
+    raw = os.getenv("MCP_API_KEY_HEADERS", "")
+    names = [h.strip().lower() for h in raw.split(",") if h.strip()] or list(
+        DEFAULT_API_KEY_HEADERS
+    )
+    return tuple(n.encode("latin-1") for n in names)
+
+
+class ApiKeyHeaderMiddleware:
+    """Promote an ``X-API-Key``-style header to ``Authorization: Bearer``."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+        self._names = _configured_headers()
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers: list[tuple[bytes, bytes]] = list(scope.get("headers", []))
+        has_authz = any(k.lower() == b"authorization" for k, _ in headers)
+        if not has_authz:
+            for name in self._names:
+                for k, v in headers:
+                    if k.lower() == name and v.strip():
+                        token = v.strip()
+                        if not token.lower().startswith(b"bearer "):
+                            token = b"Bearer " + token
+                        headers.append((b"authorization", token))
+                        scope = {**scope, "headers": headers}
+                        break
+                else:
+                    continue
+                break
+
+        await self.app(scope, receive, send)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "google-workspace-unlimited"
-version = "2.10.0"
+version = "2.11.0"
 description = "Comprehensive MCP server for Google Workspace integration - 90+ tools across Gmail, Drive, Docs, Sheets, Slides, Calendar, Forms, Chat, Photos, and Contacts with Code Mode tool discovery and OAuth 2.1 + PKCE authentication"
 readme = "README.md"
 license = "Apache-2.0"
@@ -77,7 +77,7 @@ classifiers = [
 ]
 dependencies = [
     # Core MCP Framework
-    "fastmcp[anthropic,tasks,code-mode,apps]>=3.4.6",
+    "fastmcp[anthropic,tasks,code-mode,apps]>=3.4.7",
     "litellm>=1.80.0",
     # Google APIs
     "google-api-python-client>=2.168.0",

--- a/server.py
+++ b/server.py
@@ -740,6 +740,22 @@ def main():
             if os.getenv("FASTMCP_HTTP_HOST_ORIGIN_PROTECTION") is None:
                 run_args["host_origin_protection"] = "auto"
 
+            # Accept the minted MCP API key via X-API-Key (etc.) for clients
+            # that can't set Authorization directly (e.g. Claude Desktop).
+            # FastMCP's `middleware=` kwarg lands *inside* its auth middleware,
+            # so wrap the built app instead: Starlette's add_middleware()
+            # inserts at the outermost position, ahead of bearer auth.
+            from auth.api_key_header_middleware import ApiKeyHeaderMiddleware
+
+            _orig_http_app = mcp.http_app
+
+            def _http_app_with_api_key_header(*a, **kw):
+                app = _orig_http_app(*a, **kw)
+                app.add_middleware(ApiKeyHeaderMiddleware)
+                return app
+
+            mcp.http_app = _http_app_with_api_key_header
+
             # Run the server with appropriate transport and SSL configuration
             mcp.run(**run_args)
 

--- a/uv.lock
+++ b/uv.lock
@@ -907,14 +907,14 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.4.6"
+version = "3.4.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp-slim", extra = ["client", "server"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/5a/e2c78e26233cd8a416b21513e1925435d54c008a0ec467dbdaa80369daf7/fastmcp-3.4.6.tar.gz", hash = "sha256:2287938da8364ad7071bec2d2393af6ae10fd4e836f06f506569f1456cc87eb4", size = 28808130, upload-time = "2026-08-05T14:54:42.177Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/dd/fd444d94ae7afdaf5b6dd168799d34023f576b405872d6a27d5686a9d1f4/fastmcp-3.4.7.tar.gz", hash = "sha256:43117aca886f5ee2f6a569bba91cef02b59c339aad04ba29950ff18d251c822a", size = 28808982, upload-time = "2026-08-10T21:17:55.045Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/a5/c02275db111892388972edbb05fbcbfdf1e83cbd1fd03356b3a49b93f839/fastmcp-3.4.6-py3-none-any.whl", hash = "sha256:2a29967be9f68cdd1b4cefb413ede74f83adefd923919a37aaac3611eccdd749", size = 8017, upload-time = "2026-08-05T14:54:38.473Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/14/6d950459cc831fa17fe2d1797926b6eb2d2f2af50f830e62d0c098cc1ec8/fastmcp-3.4.7-py3-none-any.whl", hash = "sha256:e4e7698cb4af5bc667b1901685261fa2f3526dc73d243a461fca42500c8dbe56", size = 8016, upload-time = "2026-08-10T21:17:51.391Z" },
 ]
 
 [package.optional-dependencies]
@@ -933,7 +933,7 @@ tasks = [
 
 [[package]]
 name = "fastmcp-slim"
-version = "3.4.6"
+version = "3.4.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "platformdirs" },
@@ -943,9 +943,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/b6/b5b9e81e67a3f39534881d2af6aa3fbd2dc367eaa070c3c932770a0c062f/fastmcp_slim-3.4.6.tar.gz", hash = "sha256:6a1e6e42c697ba90abcb1be617a26947d07316f13c6fa138ae7b0de24558e32c", size = 594167, upload-time = "2026-08-05T14:54:15.924Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/ac/7924e803368d0758ee4d6b1259066550df78f58f0f9f8bfebd5a123e957d/fastmcp_slim-3.4.7.tar.gz", hash = "sha256:06b32a358320a7dc2b2ee040ba89ea55ddc20763dff2949f384f7974b13b5d8f", size = 594357, upload-time = "2026-08-10T21:17:28.723Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/0b/02c254c46b4323ae5262b76a29af73b50a863efc5739a3454d144d3605ee/fastmcp_slim-3.4.6-py3-none-any.whl", hash = "sha256:3e08e6acb03523a47aa17f4d2ab9943e648a41e20b24084da491a732c46dffdc", size = 769174, upload-time = "2026-08-05T14:54:14.663Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/97/e0e53642cd029a9a7635ae9c548f9f2cc995af5914e487b3df795664e4be/fastmcp_slim-3.4.7-py3-none-any.whl", hash = "sha256:6c931a0089705f3f2935428ef9b2bc74ad94140adc64aab84d116d103e694b3a", size = 769370, upload-time = "2026-08-10T21:17:27.227Z" },
 ]
 
 [package.optional-dependencies]
@@ -1165,7 +1165,7 @@ wheels = [
 
 [[package]]
 name = "google-workspace-unlimited"
-version = "2.10.0"
+version = "2.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiodebug" },
@@ -1228,7 +1228,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=46.0.5" },
     { name = "fastapi", specifier = ">=0.128.0" },
     { name = "fastembed", specifier = ">=0.7.2" },
-    { name = "fastmcp", extras = ["anthropic", "tasks", "code-mode", "apps"], specifier = ">=3.4.6" },
+    { name = "fastmcp", extras = ["anthropic", "tasks", "code-mode", "apps"], specifier = ">=3.4.7" },
     { name = "google-api-python-client", specifier = ">=2.168.0" },
     { name = "google-auth-httplib2", specifier = ">=0.2.0" },
     { name = "google-auth-oauthlib", specifier = ">=1.2.2" },


### PR DESCRIPTION
## Why
Claude Desktop's custom-connector UI only accepts an approved list of custom header names (`x-api-key`, `x-api-token`, …) and does not let users set `Authorization`. Our server only read the minted per-user key from `Authorization: Bearer`.

## What
- New `auth/api_key_header_middleware.py`: outermost ASGI middleware that promotes `x-api-key` / `x-apikey` / `x-api-token` / `x-auth-token` / `x-access-token` / `x-token` (override via `MCP_API_KEY_HEADERS`) to `Authorization: Bearer <key>`. Existing `Authorization` always takes precedence; `Bearer ` prefix is optional.
- Wired in `server.py` by wrapping `mcp.http_app` and calling Starlette `add_middleware()` — FastMCP's `middleware=` kwarg lands *inside* its auth middleware, so it would never see the header.
- FastMCP bumped to `>=3.4.7`.
- Version `2.10.0 → 2.11.0` (pyproject + uv.lock).

## Test
Live server on `:8077`, real minted key:

| header | result |
|---|---|
| `x-api-key: <key>` | 200 |
| `X-Api-Token: <key>` | 200 |
| `x-api-key: Bearer <key>` | 200 |
| `authorization: Bearer <key>` | 200 |
| `x-api-key: bogus` | 401 |
| `x-nope: <key>` | 401 |

`ruff check .` / `ruff format --check .` / `uv lock --check` pass.

## Claude Desktop setup
Sign-in: **None** → Add header → name `x-api-key`, value `<minted key>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)